### PR TITLE
Skip PyPI publish when version already exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "1.3.0"
+version = "1.4.0"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Adds a version check step that queries PyPI before building/publishing
- Skips build and publish steps if the version is already on PyPI
- Fixes the `400 File already exists` error on pushes to main that don't bump the version

## Test plan
- [ ] Push to main without bumping version — workflow should skip publish
- [ ] Push to main with a new version — workflow should publish normally