### PR TITLE
ci: publish mcp2cli only from version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Publish to PyPI
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -11,6 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
+
+      - run: uv sync --extra test
+
+      - run: uv run pytest tests/ -v
 
       - run: uv build
 


### PR DESCRIPTION
## Summary

- trigger PyPI publishing only from `v*` tags instead of every push to `main`
- add the already-documented test gate (`uv sync --extra test` + `uv run pytest tests/ -v`) before `uv build` / `uv publish`
- keep this change isolated to the release workflow, separate from the open stdin JSON validation PR `#7`

## Validation

- static workflow assertions via Python/YAML parsing confirm:
  - `push.tags == ['v*']`
  - `workflow_dispatch` is available
  - the publish job now includes `uv sync --extra test`, `uv run pytest tests/ -v`, `uv build`, and `uv publish`
- `actionlint` is not installed in this environment

## Notes

- the current package version is static in `pyproject.toml`, so publishing on every merge to `main` risks either duplicate publishes or unintended immediate releases after a version bump merge