### PR TITLE
fix: derive mcp2cli version from package metadata

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
-
 import argparse
 import copy
 import hashlib
@@ -19,13 +17,31 @@ import sys
 import threading
 import time
 import webbrowser
+from importlib.metadata import PackageNotFoundError, version as package_version
 from dataclasses import dataclass, field
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
+import tomllib
 from urllib.parse import parse_qs, urlparse
 
 import anyio
 import httpx
+
+
+def _resolve_version() -> str:
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    if pyproject.exists():
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+        return data["project"]["version"]
+
+    try:
+        return package_version("mcp2cli")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _resolve_version()
 
 CACHE_DIR = Path(
     os.environ.get("MCP2CLI_CACHE_DIR", Path.home() / ".cache" / "mcp2cli")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,6 +3,8 @@
 import json
 import subprocess
 import sys
+import tomllib
+from pathlib import Path
 
 import pytest
 
@@ -210,6 +212,9 @@ class TestExecuteOpenAPI:
         json.loads(r.stdout)
 
     def test_version(self, petstore_server):
+        pyproject = tomllib.loads(
+            Path(__file__).resolve().parents[1].joinpath("pyproject.toml").read_text()
+        )
         r = subprocess.run(
             [sys.executable, "-m", "mcp2cli", "--version"],
             capture_output=True,
@@ -217,7 +222,7 @@ class TestExecuteOpenAPI:
             timeout=10,
         )
         assert r.returncode == 0
-        assert "mcp2cli" in r.stdout
+        assert r.stdout.strip() == f"mcp2cli {pyproject['project']['version']}"
 
     def test_no_mode_shows_help(self):
         r = subprocess.run(


### PR DESCRIPTION
## Summary

- derive `__version__` from the local `pyproject.toml` when running from a source checkout, falling back to installed package metadata only outside the repo tree
- tighten the `--version` regression so it asserts the exact package version instead of only checking that `mcp2cli` appears in stdout
- keep the patch independent from the open stdin-validation and publish-workflow PRs

## Validation

- `.venv/bin/python -m pytest tests/test_openapi.py -q -k version`
- `.venv/bin/python -m pytest tests/test_openapi.py -q`

## Notes

- this specifically fixes the editable/dev checkout case where package metadata can lag behind `pyproject.toml`, causing `--version` to report the wrong release number