### PR TITLE
fix: use binary stdout for --raw in OpenAPI execution

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -798,7 +798,7 @@ def execute_openapi(
             sys.exit(1)
 
     if raw:
-        print(resp.text)
+        sys.stdout.buffer.write(resp.content)
         return
 
     try:


### PR DESCRIPTION
## Summary

- `--raw` mode in `execute_openapi` uses `print(resp.text)` which decodes the HTTP response as text then re-encodes via the console codec
- On Windows (cp1252), this fails for binary formats (xlsx, parquet, shp, etc.) with `UnicodeEncodeError` because arbitrary binary bytes can't round-trip through a text codec
- Fix: write `resp.content` (raw bytes) to `sys.stdout.buffer`, bypassing all text encoding

## Reproduction

On Windows, any binary export piped to a file fails:

```bash
uvx mcp2cli --spec <any-openapi-spec> export-records --format xlsx --raw > output.xlsx
```

```
UnicodeEncodeError: 'charmap' codec can't encode character '\ufffd' in position 11:
character maps to <undefined>
```

## Fix

```diff
     if raw:
-        print(resp.text)
+        sys.stdout.buffer.write(resp.content)
         return
```

`sys.stdout.buffer.write(resp.content)` outputs the raw HTTP response bytes without any text decode/encode cycle, which is what `--raw` should do. Text-format exports (CSV, JSON, GeoJSON) continue to work identically since their bytes are valid UTF-8.

## Test plan

- [ ] Export binary format (xlsx/parquet) with `--raw` piped to file on Windows — should produce valid file
- [ ] Export text format (csv/json) with `--raw` piped to file — should still work as before
- [ ] Export binary format on Linux/macOS — should still work (was already working via UTF-8 stdout, now uses buffer directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)