### PR TITLE
Fix global options shadowing tool parameters

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1800,6 +1800,49 @@ def _fetch_mcp_tools(
 # ---------------------------------------------------------------------------
 
 
+def _split_at_subcommand(
+    argv: list[str], pre_parser: argparse.ArgumentParser
+) -> tuple[list[str], list[str]]:
+    """Split *argv* into ``(global_args, tool_args)`` at the subcommand boundary.
+
+    Walks *argv* consuming only tokens that belong to the global pre-parser
+    (options it defines and their values).  The first positional token that is
+    **not** a value of a preceding option is treated as the subcommand name;
+    everything from that point onward is returned as *tool_args* so that the
+    tool sub-parser can handle them — even when a tool parameter shares the
+    same name as a global option (e.g. ``--env``).
+    """
+    value_options: set[str] = set()
+    bool_options: set[str] = set()
+    for action in pre_parser._actions:
+        if not action.option_strings:
+            continue
+        if action.nargs == 0:
+            bool_options.update(action.option_strings)
+        else:
+            value_options.update(action.option_strings)
+
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--":
+            # Explicit separator: everything after belongs to the tool.
+            return argv[:i], argv[i + 1 :]
+        if arg.startswith("-"):
+            if arg.startswith("--") and "=" in arg:
+                i += 1  # --option=value  (single token)
+            elif arg in value_options:
+                i += 2  # --option value  (consumes next token)
+            elif arg in bool_options:
+                i += 1  # --flag
+            else:
+                i += 1  # unknown option — keep in global portion
+        else:
+            # First positional token = subcommand boundary
+            return argv[:i], argv[i:]
+    return argv, []
+
+
 def main():
     pre = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     pre.add_argument("--spec", default=None, help="OpenAPI spec URL or file path")
@@ -1910,7 +1953,12 @@ def main():
 
     pre.add_argument("--version", action="version", version=f"mcp2cli {__version__}")
 
-    pre_args, remaining = pre.parse_known_args()
+    # Split argv at the subcommand boundary so that tool parameters whose
+    # names collide with global options (e.g. --env, --refresh) are not
+    # silently consumed by the pre-parser.  See GH #15.
+    global_argv, tool_argv = _split_at_subcommand(sys.argv[1:], pre)
+    pre_args, leftover = pre.parse_known_args(global_argv)
+    remaining = leftover + tool_argv
 
     # Parse auth headers (values support env: and file: prefixes)
     auth_headers: list[tuple[str, str]] = []

--- a/tests/mcp_test_server.py
+++ b/tests/mcp_test_server.py
@@ -58,6 +58,18 @@ async def list_tools():
                 "required": ["path"],
             },
         ),
+        Tool(
+            name="deploy",
+            description="Deploy to an environment (shadows global --env and --refresh)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "env": {"type": "string", "description": "Target environment"},
+                    "refresh": {"type": "boolean", "description": "Force refresh"},
+                },
+                "required": ["env"],
+            },
+        ),
     ]
 
 
@@ -156,6 +168,13 @@ async def call_tool(name: str, arguments: dict):
         path = arguments.get("path", "/")
         recursive = arguments.get("recursive", False)
         return [TextContent(type="text", text=f'{{"path": "{path}", "recursive": {str(recursive).lower()}, "items": ["file1.txt", "file2.txt"]}}')]
+    if name == "deploy":
+        import json as _json
+
+        return [TextContent(type="text", text=_json.dumps({
+            "env": arguments.get("env", ""),
+            "refresh": arguments.get("refresh", False),
+        }))]
     return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 """Tests for helper functions and data structures."""
 
+import argparse
 import json
 import shutil
 
@@ -7,6 +8,7 @@ from mcp2cli import (
     ParamDef,
     CommandDef,
     _find_toon_cli,
+    _split_at_subcommand,
     _toon_encode,
     cache_key_for,
     coerce_value,
@@ -358,3 +360,84 @@ class TestExtractMCPCommands:
         cmds = extract_mcp_commands(tools)
         assert cmds[0].name == "list-items"
         assert cmds[0].tool_name == "list_items"
+
+
+class TestSplitAtSubcommand:
+    """Tests for _split_at_subcommand() — GH #15."""
+
+    @staticmethod
+    def _pre():
+        """Build a pre-parser with representative global options."""
+        pre = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+        pre.add_argument("--spec", default=None)
+        pre.add_argument("--mcp", default=None)
+        pre.add_argument("--env", action="append", default=[])
+        pre.add_argument("--pretty", action="store_true")
+        pre.add_argument("--refresh", action="store_true")
+        pre.add_argument("--cache-ttl", type=int, default=3600)
+        pre.add_argument("--auth-header", action="append", default=[])
+        pre.add_argument("--version", action="version", version="test")
+        return pre
+
+    def test_basic_split(self):
+        g, t = _split_at_subcommand(
+            ["--mcp", "http://server", "my-tool", "--env", "prod"], self._pre()
+        )
+        assert g == ["--mcp", "http://server"]
+        assert t == ["my-tool", "--env", "prod"]
+
+    def test_no_subcommand(self):
+        g, t = _split_at_subcommand(
+            ["--mcp", "http://server", "--pretty"], self._pre()
+        )
+        assert g == ["--mcp", "http://server", "--pretty"]
+        assert t == []
+
+    def test_boolean_flag_before_subcommand(self):
+        g, t = _split_at_subcommand(
+            ["--pretty", "--mcp", "http://server", "tool"], self._pre()
+        )
+        assert g == ["--pretty", "--mcp", "http://server"]
+        assert t == ["tool"]
+
+    def test_append_option_repeated(self):
+        g, t = _split_at_subcommand(
+            ["--env", "FOO=BAR", "--env", "BAZ=QUX", "tool"], self._pre()
+        )
+        assert g == ["--env", "FOO=BAR", "--env", "BAZ=QUX"]
+        assert t == ["tool"]
+
+    def test_double_dash_separator(self):
+        g, t = _split_at_subcommand(
+            ["--mcp", "http://server", "--", "tool", "--env", "x"], self._pre()
+        )
+        assert g == ["--mcp", "http://server"]
+        assert t == ["tool", "--env", "x"]
+
+    def test_equals_form(self):
+        g, t = _split_at_subcommand(["--mcp=http://server", "tool"], self._pre())
+        assert g == ["--mcp=http://server"]
+        assert t == ["tool"]
+
+    def test_unknown_option_before_subcommand(self):
+        g, t = _split_at_subcommand(["--unknown", "tool"], self._pre())
+        assert g == ["--unknown"]
+        assert t == ["tool"]
+
+    def test_empty_argv(self):
+        g, t = _split_at_subcommand([], self._pre())
+        assert g == []
+        assert t == []
+
+    def test_value_not_treated_as_subcommand(self):
+        g, t = _split_at_subcommand(["--mcp", "http://server"], self._pre())
+        assert g == ["--mcp", "http://server"]
+        assert t == []
+
+    def test_tool_env_preserved(self):
+        """Tool --env must not end up in the global portion."""
+        g, t = _split_at_subcommand(
+            ["--mcp", "http://s", "deploy", "--env", "production"], self._pre()
+        )
+        assert g == ["--mcp", "http://s"]
+        assert t == ["deploy", "--env", "production"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -91,6 +91,29 @@ class TestMCPStdio:
         r = self._run("--env", "TEST_VAR=hello", "echo", "--message", "test")
         assert r.returncode == 0
 
+    # --- GH #15: global options must not shadow tool parameters ---
+
+    def test_tool_param_not_shadowed_by_global_env(self):
+        """Tool --env parameter must not be consumed by global --env."""
+        r = self._run("deploy", "--env", "production")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["env"] == "production"
+
+    def test_tool_param_not_shadowed_by_global_refresh(self):
+        """Tool --refresh must not be consumed by global --refresh."""
+        r = self._run("deploy", "--env", "staging", "--refresh")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["refresh"] is True
+
+    def test_global_and_tool_env_coexist(self):
+        """Global --env before subcommand + tool --env after subcommand."""
+        r = self._run("--env", "X=1", "deploy", "--env", "production")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["env"] == "production"
+
     def test_tool_caching(self, tmp_path, monkeypatch):
         """Run twice — second should use cached tool list."""
         import mcp2cli

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -107,7 +107,7 @@ class TestExecuteOpenAPI:
         assert "create-pet" in r.stdout
 
     def test_list_pets(self, petstore_server):
-        r = self._run(petstore_server, "list-pets", "--pretty")
+        r = self._run(petstore_server, "--pretty", "list-pets")
         assert r.returncode == 0
         data = json.loads(r.stdout)
         assert isinstance(data, list)


### PR DESCRIPTION
## Summary

- Fixes #15 — when a tool parameter name (e.g. `env`, `refresh`) matched a global option, `parse_known_args()` silently consumed it before the subparser could see it, causing the tool call to fail
- Adds `_split_at_subcommand()` helper that splits `sys.argv` at the subcommand boundary so only pre-subcommand tokens are fed to the global pre-parser
- Global options must now be placed **before** the subcommand name (standard CLI convention)

## Test plan

- [x] 10 unit tests for `_split_at_subcommand()` covering: basic split, no subcommand, boolean flags, repeated append options, `--` separator, `=` form, unknown options, empty argv, value-not-as-subcommand, tool env preserved
- [x] 3 integration tests proving tool params are no longer shadowed (`--env`, `--refresh`, both global+tool `--env` coexisting)
- [x] All 150 existing tests pass