### PR TITLE
fix: reject session-start with OAuth over HTTP

### DIFF
--- a/src/mcp2cli/_cli.py
+++ b/src/mcp2cli/_cli.py
@@ -569,6 +569,17 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
     env_vars = dict(_parse_kv_list(pre_args.env, "=", "env"))
 
     _validate_source_modes(pre_args, pre, remaining)
+
+    use_oauth = (
+        pre_args.oauth or pre_args.oauth_client_id or pre_args.oauth_client_secret
+    )
+    if pre_args.session_start and pre_args.mcp and use_oauth:
+        print(
+            "Error: OAuth is not yet supported with --session-start over HTTP transports",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     oauth_provider = _setup_oauth(pre_args)
 
     if _handle_session_operations(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -162,6 +162,17 @@ class TestOAuthCLIValidation:
         assert r.returncode != 0
         assert "not supported with --mcp-stdio" in r.stderr
 
+    def test_oauth_with_session_start_over_http_errors(self):
+        r = self._run(
+            "--mcp",
+            "https://example.com/mcp",
+            "--oauth",
+            "--session-start",
+            "test-session",
+        )
+        assert r.returncode != 0
+        assert "not yet supported with --session-start over HTTP transports" in r.stderr
+
     def test_oauth_with_spec_accepted(self):
         """--oauth with --spec should not error on the flag itself (may fail on connection)."""
         r = self._run("--spec", "https://example.com/openapi.json", "--oauth", "--list")


### PR DESCRIPTION
## Summary

- fail fast when `--session-start` is combined with `--mcp ... --oauth`
- stop the CLI from implying session-daemon OAuth works before the auth context is actually propagated into the daemon path
- add a focused OAuth CLI regression covering the new guard

## Validation

- `.venv/bin/python -m pytest tests/test_oauth.py -q`

## Notes

- this PR intentionally chooses the narrow safe behavior (explicit rejection) instead of trying to serialize `oauth_provider` into the daemon process in one step
- it stays independent from the open stdin-validation, publish-workflow, version-sync, and corrupt-cache PRs