### PR TITLE
Add IPv6 loopback support for OAuth redirect URI

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -497,7 +497,7 @@ def build_oauth_provider(
     from mcp.client.auth.oauth2 import OAuthClientProvider
     from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 
-    _LOOPBACK_HOSTS = {"localhost", "127.0.0.1"}
+    _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
     if redirect_uri is not None:
         parsed = urlparse(redirect_uri)
@@ -518,7 +518,7 @@ def build_oauth_provider(
         if (parsed.hostname or "") not in _LOOPBACK_HOSTS:
             print(
                 f"Error: --oauth-redirect-uri host must be a loopback address "
-                f"(localhost or 127.0.0.1), got '{parsed.hostname}'.",
+                f"(localhost, 127.0.0.1, or ::1), got '{parsed.hostname}'.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -557,7 +557,15 @@ def build_oauth_provider(
     _CallbackHandler.error = None
     _CallbackHandler.done = threading.Event()
 
-    server = HTTPServer((callback_host, port), _CallbackHandler)
+    if callback_host == "::1":
+        import socket as _socket
+
+        class _IPv6HTTPServer(HTTPServer):
+            address_family = _socket.AF_INET6
+
+        server = _IPv6HTTPServer((callback_host, port), _CallbackHandler)
+    else:
+        server = HTTPServer((callback_host, port), _CallbackHandler)
 
     async def redirect_handler(auth_url: str) -> None:
         print(f"Opening browser for authorization...", file=sys.stderr)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -168,6 +168,16 @@ class TestBuildOAuthProvider:
                 redirect_uri="http://example.com:3334/callback",
             )
 
+    def test_redirect_uri_ipv6_loopback_accepted(self):
+        """::1 (IPv6 loopback) should be accepted as a valid redirect host."""
+        from mcp.client.auth.oauth2 import OAuthClientProvider
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://[::1]:19878/callback",
+        )
+        assert isinstance(provider, OAuthClientProvider)
+
     def test_auth_code_random_port_when_no_redirect_uri(self, monkeypatch):
         """Without redirect_uri, _find_free_port() is called and the default URI is built."""
         called_with = []


### PR DESCRIPTION
## Summary

- Accept `::1` (IPv6 loopback) as a valid host in `--oauth-redirect-uri`
- Bind the callback server with `AF_INET6` when an IPv6 address is used
- Update error message to list all accepted loopback hosts

Follow-up to #26 — builds on the redirect URI validation contributed by @tremlin.

## Test plan

- [x] `test_redirect_uri_ipv6_loopback_accepted` — verifies `http://[::1]:19878/callback` is accepted
- [x] All 65 existing OAuth and bake tests pass