### PR TITLE
feat!: parse JSON object/array CLI flag values and remove --jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,8 @@ mcp2cli --spec ./spec.json --pretty list-pets
 # Raw response body (no JSON parsing)
 mcp2cli --spec ./spec.json --raw get-data
 
-# Filter JSON with jq (preferred over Python for JSON processing)
-mcp2cli --spec ./spec.json list-pets --jq '.[].name'
-mcp2cli --spec ./spec.json list-pets --jq '[.[] | select(.status == "available")] | length'
-
 # Truncate large responses to first N records
 mcp2cli --spec ./spec.json list-records --head 5
-mcp2cli --spec ./spec.json list-records --head 3 --jq '.'  # preview then filter
 
 # Pipe-friendly (compact JSON when not a TTY)
 mcp2cli --spec ./spec.json list-pets | jq '.[] | .name'
@@ -295,7 +290,6 @@ Options:
   --pretty                Pretty-print JSON output
   --raw                   Print raw response body
   --toon                  Encode output as TOON (token-efficient for LLMs)
-  --jq EXPR               Filter JSON output through jq expression
   --head N                Limit output to first N records (arrays)
   --version               Show version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "2.8.1"
+version = "3.0.0"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/skills/mcp2cli/SKILL.md
+++ b/skills/mcp2cli/SKILL.md
@@ -73,7 +73,6 @@ Options:
   --pretty                Pretty-print JSON output
   --raw                   Print raw response body
   --toon                  Encode output as TOON (token-efficient for LLMs)
-  --jq EXPR               Filter JSON output through jq expression
   --head N                Limit output to first N records (arrays)
   --version               Show version
 
@@ -236,32 +235,11 @@ mcp2cli --mcp https://mcp.example.com/sse --toon list-tags
 
 Best for large uniform arrays — 40-60% fewer tokens than JSON.
 
-### JSON filtering with --jq
-
-Prefer `--jq` over Python scripts for JSON processing — it uses fewer tokens and avoids script overhead.
-
-```bash
-# Extract specific fields
-mcp2cli --spec ./spec.json list-pets --jq '.[].name'
-
-# Count results
-mcp2cli --mcp https://example.com/sse list-items --jq 'length'
-
-# Complex filtering
-mcp2cli --spec ./spec.json list-pets --jq '[.[] | select(.status == "available")] | length'
-
-# Preview large datasets (--head truncates before --jq processes)
-mcp2cli --spec ./spec.json list-records --head 3 --jq '.'
-```
-
 ### Truncating large responses with --head
 
 ```bash
 # Preview first 3 records from a potentially huge dataset
 mcp2cli --spec ./spec.json list-records --head 3 --pretty
-
-# Combine with --jq for targeted inspection
-mcp2cli --spec ./spec.json list-records --head 1 --jq 'keys'
 ```
 
 `--head N` slices JSON arrays to the first N elements. Useful for datasets with oversized fields (e.g. geo_shape polygons at ~200KB per record).
@@ -340,21 +318,20 @@ When the user asks to create a skill from an MCP server, OpenAPI spec, or GraphQ
 
    **Anti-Patterns & Gotchas** — document every surprise found during testing:
    - Date syntax quirks (e.g. `date'2022'` vs `"2022"`)
-   - Fields that produce oversized output (e.g. geo_shape → use `--head` or `--jq` to exclude)
+   - Fields that produce oversized output (e.g. geo_shape → use `--head` to limit)
    - Parameter name inconsistencies across endpoints
    - Scope/filtering confusion (e.g. dataset contains national data, not just regional)
    - Binary export corruption risks (e.g. don't pipe binary formats through text encoding)
 
-   **Output Processing** — recommend `--jq` over Python for JSON filtering:
+   **Output Processing** — use `--pretty` for readable JSON, `--head` to limit results, or pipe to `jq` for filtering:
    ```bash
-   # Extract specific fields
-   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records --jq '.[].name'
-   # Count results
-   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records --jq 'length'
-   # Filter by condition
-   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records --jq '[.[] | select(.status == "active")]'
+   # Pretty-print results
+   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records --pretty
+   # Limit large datasets
+   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records --head 5
+   # Filter with jq (pipe)
+   bash ${CLAUDE_SKILL_DIR}/scripts/myapi list-records | jq '.[].name'
    ```
-   Prefer `--jq` over piping to Python for JSON processing — it is more token-efficient and avoids unnecessary script complexity.
 
    **Export Formats** (if the API supports multiple output types):
    - List supported formats (JSON, CSV, xlsx, parquet, etc.)

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -219,6 +219,16 @@ def coerce_value(value, schema: dict):
         return int(value)
     if t == "number":
         return float(value)
+    # Schema-less fallback: try to parse JSON objects/arrays from strings
+    if t is None and isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped[0] in ('{', '['):
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, (dict, list)):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
     return value
 
 
@@ -257,31 +267,6 @@ def _toon_encode(json_str: str) -> str | None:
     return None
 
 
-def _run_jq(json_str: str, expr: str) -> str:
-    """Pipe JSON through jq with the given expression. Exits on failure."""
-    if not shutil.which("jq"):
-        print(
-            "Error: --jq requires jq to be installed. "
-            "See https://jqlang.github.io/jq/",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    try:
-        result = subprocess.run(
-            ["jq", expr],
-            input=json_str,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            print(f"jq error: {result.stderr.strip()}", file=sys.stderr)
-            sys.exit(1)
-        return result.stdout
-    except subprocess.TimeoutExpired:
-        print("Error: jq timed out", file=sys.stderr)
-        sys.exit(1)
-
 
 def _apply_head(data, n: int):
     """Truncate data to first N elements (array) or return as-is (dict/scalar)."""
@@ -296,7 +281,6 @@ def output_result(
     pretty: bool = False,
     raw: bool = False,
     toon: bool = False,
-    jq_expr: str | None = None,
     head: int | None = None,
 ):
     if raw:
@@ -313,9 +297,6 @@ def output_result(
             return
     if head is not None:
         data = _apply_head(data, head)
-    if jq_expr:
-        print(_run_jq(json.dumps(data), jq_expr), end="")
-        return
     if toon:
         encoded = _toon_encode(json.dumps(data))
         if encoded is not None:
@@ -860,6 +841,7 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
                     description=(param.get("description") or param["name"]) + suffix,
                     choices=schema.get("enum"),
                     location=param.get("in", "query"),
+                    schema=schema,
                 )
                 params.append(p)
 
@@ -908,6 +890,7 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
                     description=(prop_schema.get("description") or prop_name) + suffix,
                     choices=prop_schema.get("enum"),
                     location=loc,
+                    schema=prop_schema,
                 )
                 params.append(p)
 
@@ -1417,7 +1400,6 @@ def execute_graphql(
     toon: bool = False,
     fields_override: str | None = None,
     oauth_provider: "httpx.Auth | None" = None,
-    jq_expr: str | None = None,
     head: int | None = None,
 ):
     """Build and execute a GraphQL query/mutation."""
@@ -1442,13 +1424,13 @@ def execute_graphql(
             print(f"GraphQL error: {msgs}", file=sys.stderr)
             sys.exit(1)
         # Partial errors — include them in output
-        output_result(result, pretty=pretty, raw=raw, toon=toon, jq_expr=jq_expr, head=head)
+        output_result(result, pretty=pretty, raw=raw, toon=toon, head=head)
         return
 
     data = result.get("data", {})
     # Extract the specific field's data
     field_data = data.get(field_name, data)
-    output_result(field_data, pretty=pretty, raw=raw, toon=toon, jq_expr=jq_expr, head=head)
+    output_result(field_data, pretty=pretty, raw=raw, toon=toon, head=head)
 
 
 def handle_graphql(
@@ -1464,7 +1446,6 @@ def handle_graphql(
     toon: bool = False,
     fields_override: str | None = None,
     oauth_provider: "httpx.Auth | None" = None,
-    jq_expr: str | None = None,
     head: int | None = None,
     verbose: bool = False,
     sort_mode: str | None = None,
@@ -1505,7 +1486,6 @@ def handle_graphql(
     execute_graphql(
         args, cmd, url, schema, auth_headers, pretty, raw, toon=toon,
         fields_override=fields_override, oauth_provider=oauth_provider,
-        jq_expr=jq_expr, head=head,
     )
 
     # Record usage after successful execution
@@ -2053,7 +2033,7 @@ def _collect_openapi_params(
             if val is None:
                 continue
             if p.location == "query":
-                query_params[p.original_name] = val
+                query_params[p.original_name] = coerce_value(val, p.schema)
             elif p.location == "header":
                 extra_headers[p.original_name] = str(val)
     else:
@@ -2081,7 +2061,7 @@ def _collect_openapi_params(
                         files[p.original_name] = (fp.name, open(fp, "rb"), mime)
                     continue
                 if val is not None:
-                    body[p.original_name] = val
+                    body[p.original_name] = coerce_value(val, p.schema)
             if not body:
                 body = None
         # Also collect query params for non-GET
@@ -2089,7 +2069,7 @@ def _collect_openapi_params(
             if p.location == "query":
                 val = getattr(args, p.name.replace("-", "_"), None)
                 if val is not None:
-                    query_params[p.original_name] = val
+                    query_params[p.original_name] = coerce_value(val, p.schema)
 
     return path, query_params, extra_headers, body, files
 
@@ -2103,7 +2083,6 @@ def execute_openapi(
     raw: bool,
     toon: bool = False,
     oauth_provider: "httpx.Auth | None" = None,
-    jq_expr: str | None = None,
     head: int | None = None,
 ):
     path, query_params, extra_headers, body, files = _collect_openapi_params(cmd, args)
@@ -2156,7 +2135,7 @@ def execute_openapi(
         print(resp.text)
         return
 
-    output_result(data, pretty=pretty, toon=toon, jq_expr=jq_expr, head=head)
+    output_result(data, pretty=pretty, toon=toon, head=head)
 
 
 # ---------------------------------------------------------------------------
@@ -2184,7 +2163,6 @@ def run_mcp_http(
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
     search_pattern: str | None = None,
-    jq_expr: str | None = None,
     head: int | None = None,
     verbose: bool = False,
     sort_mode: str | None = None,
@@ -2199,7 +2177,6 @@ def run_mcp_http(
         prompt_name=prompt_name,
         prompt_arguments=prompt_arguments,
         search_pattern=search_pattern,
-        jq_expr=jq_expr,
         head=head,
         verbose=verbose,
         sort_mode=sort_mode,
@@ -2289,7 +2266,6 @@ def run_mcp_stdio(
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
     search_pattern: str | None = None,
-    jq_expr: str | None = None,
     head: int | None = None,
     verbose: bool = False,
     sort_mode: str | None = None,
@@ -2304,7 +2280,6 @@ def run_mcp_stdio(
         prompt_name=prompt_name,
         prompt_arguments=prompt_arguments,
         search_pattern=search_pattern,
-        jq_expr=jq_expr,
         head=head,
         verbose=verbose,
         sort_mode=sort_mode,
@@ -2360,7 +2335,6 @@ async def _mcp_session(
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
     search_pattern: str | None = None,
-    jq_expr: str | None = None,
     head: int | None = None,
     verbose: bool = False,
     sort_mode: str | None = None,
@@ -2372,7 +2346,6 @@ async def _mcp_session(
     if resource_action:
         await _handle_resources(
             session, resource_action, resource_uri, pretty, raw, toon,
-            jq_expr=jq_expr, head=head,
         )
         return
 
@@ -2380,7 +2353,6 @@ async def _mcp_session(
     if prompt_action:
         await _handle_prompts(
             session, prompt_action, prompt_name, prompt_arguments, pretty, raw, toon,
-            jq_expr=jq_expr, head=head,
         )
         return
 
@@ -2423,7 +2395,7 @@ async def _mcp_session(
     result = await session.call_tool(tool_name, arguments or {})
 
     text = _extract_content_parts(result.content)
-    output_result(text, pretty=pretty, raw=raw, toon=toon, jq_expr=jq_expr, head=head)
+    output_result(text, pretty=pretty, raw=raw, toon=toon, head=head)
 
 
 # ---------------------------------------------------------------------------
@@ -2433,9 +2405,8 @@ async def _mcp_session(
 
 async def _handle_resources(
     session, action: str, uri: str | None, pretty: bool, raw: bool, toon: bool,
-    jq_expr: str | None = None, head: int | None = None,
 ):
-    _out = dict(pretty=pretty, raw=raw, toon=toon, jq_expr=jq_expr, head=head)
+    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head)
     if action == "list":
         result = await session.list_resources()
         data = [
@@ -2487,10 +2458,9 @@ async def _handle_prompts(
     pretty: bool,
     raw: bool,
     toon: bool,
-    jq_expr: str | None = None,
     head: int | None = None,
 ):
-    _out = dict(pretty=pretty, raw=raw, toon=toon, jq_expr=jq_expr, head=head)
+    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head)
     if action == "list":
         result = await session.list_prompts()
         data = [
@@ -3026,7 +2996,6 @@ def handle_mcp(
     prompt_arguments: dict | None = None,
     search_pattern: str | None = None,
     bake_config: BakeConfig | None = None,
-    jq_expr: str | None = None,
     head: int | None = None,
     verbose: bool = False,
     sort_mode: str | None = None,
@@ -3053,7 +3022,6 @@ def handle_mcp(
             prompt_action=prompt_action,
             prompt_name=prompt_name,
             prompt_arguments=prompt_arguments,
-            jq_expr=jq_expr,
             head=head,
         )
         _dispatch_mcp_call(
@@ -3089,7 +3057,6 @@ def handle_mcp(
             None, None, True, pretty, raw, key, ttl, refresh,
             toon=toon, transport=transport, oauth_provider=oauth_provider,
             search_pattern=search_pattern,
-            jq_expr=jq_expr, head=head,
             verbose=verbose,
             sort_mode=sort_mode, top=top, compact=compact,
             source_hash=src_hash,
@@ -3139,7 +3106,6 @@ def handle_mcp(
         source, is_stdio, auth_headers, env_vars,
         cmd.tool_name, arguments, False, pretty, raw, key, ttl, refresh,
         toon=toon, transport=transport, oauth_provider=oauth_provider,
-        jq_expr=jq_expr, head=head,
     )
 
     # Record usage after successful execution
@@ -3366,12 +3332,6 @@ def _build_main_parser() -> argparse.ArgumentParser:
             "list-users) and 15-20%% for semi-uniform data. Best for LLM consumption "
             "of large result sets. Requires @toon-format/cli (npm install -g @toon-format/cli)."
         ),
-    )
-    pre.add_argument(
-        "--jq",
-        default=None,
-        metavar="EXPR",
-        help="Filter JSON output through jq (e.g. '.[] | .name'). Requires jq installed.",
     )
     pre.add_argument(
         "--head",
@@ -3629,14 +3589,12 @@ def _handle_session_operations(
         result = _session_request(sess_name, "list_resources")
         output_result(
             result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-            jq_expr=pre_args.jq, head=pre_args.head,
         )
         return True
     if pre_args.list_resource_templates:
         result = _session_request(sess_name, "list_resource_templates")
         output_result(
             result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-            jq_expr=pre_args.jq, head=pre_args.head,
         )
         return True
     if pre_args.read_resource:
@@ -3645,14 +3603,12 @@ def _handle_session_operations(
         )
         output_result(
             result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-            jq_expr=pre_args.jq, head=pre_args.head,
         )
         return True
     if pre_args.list_prompts:
         result = _session_request(sess_name, "list_prompts")
         output_result(
             result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-            jq_expr=pre_args.jq, head=pre_args.head,
         )
         return True
     if pre_args.get_prompt:
@@ -3668,7 +3624,6 @@ def _handle_session_operations(
         )
         output_result(
             result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-            jq_expr=pre_args.jq, head=pre_args.head,
         )
         return True
     if pre_args.list_commands:
@@ -3837,7 +3792,6 @@ def _handle_openapi_mode(
         args, cmd, base_url, auth_headers,
         pre_args.pretty, pre_args.raw, toon=pre_args.toon,
         oauth_provider=oauth_provider,
-        jq_expr=pre_args.jq, head=pre_args.head,
     )
 
     # Record usage after successful execution
@@ -3853,11 +3807,6 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
     global_argv, tool_argv = _split_at_subcommand(argv, pre)
     pre_args, leftover = pre.parse_known_args(global_argv)
     remaining = leftover + tool_argv
-
-    # Validate mutually exclusive output flags
-    if pre_args.jq and pre_args.toon:
-        print("Error: --jq and --toon are mutually exclusive.", file=sys.stderr)
-        sys.exit(1)
 
     # --search implies --list
     search_pattern = pre_args.search_pattern
@@ -3897,7 +3846,6 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
             toon=pre_args.toon,
             fields_override=pre_args.fields,
             oauth_provider=oauth_provider,
-            jq_expr=pre_args.jq,
             head=pre_args.head,
             verbose=pre_args.verbose,
             sort_mode=pre_args.sort_mode,
@@ -3932,7 +3880,6 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
             prompt_arguments=prompt_arguments,
             search_pattern=search_pattern,
             bake_config=bake_config,
-            jq_expr=pre_args.jq,
             head=pre_args.head,
             verbose=pre_args.verbose,
             sort_mode=pre_args.sort_mode,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,8 +8,8 @@ from mcp2cli import (
     ParamDef,
     CommandDef,
     _apply_head,
+    _collect_openapi_params,
     _find_toon_cli,
-    _run_jq,
     _split_at_subcommand,
     _toon_encode,
     cache_key_for,
@@ -114,6 +114,22 @@ class TestCoerceValue:
     def test_non_array_unaffected(self):
         assert coerce_value("hello", {"type": "string"}) == "hello"
 
+    def test_schemaless_json_object(self):
+        """JSON object string is parsed when schema has no type."""
+        assert coerce_value('{"key": "val"}', {}) == {"key": "val"}
+
+    def test_schemaless_json_array(self):
+        """JSON array string is parsed when schema has no type."""
+        assert coerce_value('[1, 2, 3]', {}) == [1, 2, 3]
+
+    def test_schemaless_plain_string(self):
+        """Plain string stays a string when schema has no type."""
+        assert coerce_value("hello", {}) == "hello"
+
+    def test_schemaless_invalid_json(self):
+        """String that looks like JSON but isn't stays as string."""
+        assert coerce_value("{not valid json", {}) == "{not valid json"
+
 
 class TestToKebab:
     def test_camel_case(self):
@@ -174,32 +190,6 @@ class TestOutputResult:
         assert '"a": 1' in captured.out  # fell back to JSON
         assert "TOON CLI" in captured.err  # printed warning
 
-    def test_jq_filters_dict(self, capsys, monkeypatch):
-        """--jq filters JSON output through jq."""
-        monkeypatch.setattr("mcp2cli._run_jq", lambda json_str, expr: '"Alice"\n')
-        output_result({"name": "Alice", "age": 30}, jq_expr=".name")
-        assert capsys.readouterr().out.strip() == '"Alice"'
-
-    def test_jq_filters_list(self, capsys, monkeypatch):
-        monkeypatch.setattr("mcp2cli._run_jq", lambda json_str, expr: "2\n")
-        output_result([{"a": 1}, {"a": 2}], jq_expr="length")
-        assert capsys.readouterr().out.strip() == "2"
-
-    def test_jq_skipped_for_raw(self, capsys, monkeypatch):
-        """--raw takes priority over --jq."""
-        called = []
-        monkeypatch.setattr("mcp2cli._run_jq", lambda *a: called.append(1) or "x")
-        output_result({"a": 1}, raw=True, jq_expr=".a")
-        assert not called
-
-    def test_jq_non_json_string_passthrough(self, capsys, monkeypatch):
-        """Non-JSON strings bypass jq processing."""
-        called = []
-        monkeypatch.setattr("mcp2cli._run_jq", lambda *a: called.append(1) or "x")
-        output_result("plain text", jq_expr=".a")
-        assert capsys.readouterr().out.strip() == "plain text"
-        assert not called
-
     def test_head_truncates_list(self, capsys):
         output_result([{"a": 1}, {"a": 2}, {"a": 3}], head=2, pretty=True)
         out = json.loads(capsys.readouterr().out)
@@ -210,39 +200,6 @@ class TestOutputResult:
         output_result({"a": 1, "b": 2}, head=1, pretty=True)
         out = json.loads(capsys.readouterr().out)
         assert out == {"a": 1, "b": 2}
-
-    def test_head_before_jq(self, capsys, monkeypatch):
-        """--head truncates before --jq processes."""
-        def mock_jq(json_str, expr):
-            data = json.loads(json_str)
-            return f"{len(data)}\n"
-        monkeypatch.setattr("mcp2cli._run_jq", mock_jq)
-        output_result([1, 2, 3, 4, 5], head=2, jq_expr="length")
-        assert capsys.readouterr().out.strip() == "2"
-
-
-class TestRunJq:
-    def test_basic_filter(self):
-        if not shutil.which("jq"):
-            import pytest
-            pytest.skip("jq not available")
-        result = _run_jq('{"name": "Alice"}', ".name")
-        assert result.strip() == '"Alice"'
-
-    def test_jq_not_found(self, monkeypatch):
-        import pytest
-        monkeypatch.setattr(shutil, "which", lambda cmd: None)
-        with pytest.raises(SystemExit):
-            _run_jq("{}", ".")
-
-    def test_invalid_expression(self):
-        if not shutil.which("jq"):
-            import pytest
-            pytest.skip("jq not available")
-        import pytest
-        with pytest.raises(SystemExit):
-            _run_jq('{"a": 1}', ".invalid[")
-
 
 class TestApplyHead:
     def test_list_truncation(self):
@@ -335,14 +292,20 @@ class TestCaching:
         assert load_cached("nonexistent", 3600) is None
 
     def test_cache_key_deterministic(self):
-        k1 = cache_key_for("https://example.com/spec.json")
-        k2 = cache_key_for("https://example.com/spec.json")
+        config = {"url": "https://example.com/spec.json"}
+        k1 = cache_key_for(config)
+        k2 = cache_key_for(config)
         assert k1 == k2
 
     def test_cache_key_different(self):
-        k1 = cache_key_for("https://example.com/a.json")
-        k2 = cache_key_for("https://example.com/b.json")
+        k1 = cache_key_for({"url": "https://example.com/a.json"})
+        k2 = cache_key_for({"url": "https://example.com/b.json"})
         assert k1 != k2
+
+    def test_cache_key_ignores_excluded_fields(self):
+        k1 = cache_key_for({"url": "https://example.com/spec.json", "cache_ttl": 60})
+        k2 = cache_key_for({"url": "https://example.com/spec.json", "cache_ttl": 3600})
+        assert k1 == k2
 
 
 class TestResolveRefs:
@@ -411,6 +374,19 @@ class TestExtractOpenAPICommands:
         list_pets = next(c for c in cmds if c.name == "list-pets")
         status_param = next(p for p in list_pets.params if p.name == "status")
         assert status_param.choices == ["available", "pending", "sold"]
+
+    def test_schema_preserved_on_params(self, petstore_spec):
+        """Extracted OpenAPI commands preserve schema on ParamDef."""
+        cmds = extract_openapi_commands(petstore_spec)
+        create = next(c for c in cmds if c.name == "create-pet")
+        name_param = next(p for p in create.params if p.original_name == "name")
+        assert name_param.schema.get("type") == "string"
+        age_param = next(p for p in create.params if p.original_name == "age")
+        assert age_param.schema.get("type") == "integer"
+        # Query param schema
+        list_pets = next(c for c in cmds if c.name == "list-pets")
+        limit_param = next(p for p in list_pets.params if p.original_name == "limit")
+        assert limit_param.schema.get("type") == "integer"
 
 
 class TestExtractMCPCommands:
@@ -528,16 +504,6 @@ class TestSplitAtSubcommand:
         assert g == ["--mcp", "http://s"]
         assert t == ["deploy", "--env", "production"]
 
-    def test_jq_value_not_treated_as_subcommand(self):
-        """--jq's expression value should not be mistaken for a subcommand."""
-        pre = self._pre()
-        pre.add_argument("--jq", default=None)
-        g, t = _split_at_subcommand(
-            ["--mcp", "http://s", "--jq", ".name", "my-tool"], pre
-        )
-        assert g == ["--mcp", "http://s", "--jq", ".name"]
-        assert t == ["my-tool"]
-
     def test_head_value_not_treated_as_subcommand(self):
         """--head's numeric value should not be mistaken for a subcommand."""
         pre = self._pre()
@@ -547,3 +513,99 @@ class TestSplitAtSubcommand:
         )
         assert g == ["--mcp", "http://s", "--head", "5"]
         assert t == ["my-tool"]
+
+
+class TestCollectOpenAPIParams:
+    def test_body_params_coerced_object(self):
+        """Body params with object schema get JSON-parsed."""
+        cmd = CommandDef(
+            name="create-item",
+            method="post",
+            path="/items",
+            has_body=True,
+            params=[
+                ParamDef(
+                    name="metadata",
+                    original_name="metadata",
+                    python_type=str,
+                    location="body",
+                    schema={"type": "object"},
+                ),
+                ParamDef(
+                    name="count",
+                    original_name="count",
+                    python_type=str,
+                    location="body",
+                    schema={"type": "integer"},
+                ),
+            ],
+        )
+        args = argparse.Namespace(
+            metadata='{"key": "val"}',
+            count="42",
+            stdin=False,
+        )
+        _, _, _, body, _ = _collect_openapi_params(cmd, args)
+        assert body == {"metadata": {"key": "val"}, "count": 42}
+
+    def test_body_params_coerced_array(self):
+        """Body params with array schema get JSON-parsed."""
+        cmd = CommandDef(
+            name="create-item",
+            method="post",
+            path="/items",
+            has_body=True,
+            params=[
+                ParamDef(
+                    name="tags",
+                    original_name="tags",
+                    python_type=str,
+                    location="body",
+                    schema={"type": "array"},
+                ),
+            ],
+        )
+        args = argparse.Namespace(tags='["a","b"]', stdin=False)
+        _, _, _, body, _ = _collect_openapi_params(cmd, args)
+        assert body == {"tags": ["a", "b"]}
+
+    def test_query_params_coerced(self):
+        """Query params get coerced (e.g., integer)."""
+        cmd = CommandDef(
+            name="list-items",
+            method="get",
+            path="/items",
+            params=[
+                ParamDef(
+                    name="limit",
+                    original_name="limit",
+                    python_type=int,
+                    location="query",
+                    schema={"type": "integer"},
+                ),
+            ],
+        )
+        args = argparse.Namespace(limit="10")
+        _, query, _, _, _ = _collect_openapi_params(cmd, args)
+        assert query == {"limit": 10}
+
+    def test_body_schemaless_json_object(self):
+        """Body params without schema type still parse JSON objects."""
+        cmd = CommandDef(
+            name="run-script",
+            method="post",
+            path="/run",
+            has_body=True,
+            params=[
+                ParamDef(
+                    name="args",
+                    original_name="args",
+                    python_type=str,
+                    location="body",
+                    schema={},
+                ),
+            ],
+        )
+        args = argparse.Namespace(args='{"key": "value"}', stdin=False)
+        _, _, _, body, _ = _collect_openapi_params(cmd, args)
+        assert body == {"args": {"key": "value"}}

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "2.7.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- **Fix OpenAPI JSON coercion**: CLI flag values like `--args '{"key": "value"}'` are now parsed as JSON objects/arrays instead of being sent as strings. This brings OpenAPI in line with MCP and GraphQL, which already called `coerce_value()`.
- **Schema-less fallback**: Values starting with `{` or `[` are tried as JSON even when the OpenAPI spec lacks type info.
- **Remove `--jq` flag**: Removes the external `jq` dependency. Use `--pretty` for formatting or pipe to `jq` for filtering.
- **Version bump**: 2.8.1 → 3.0.0 (breaking change due to `--jq` removal).

## Test plan

- [x] All 80 tests pass (`uv run --extra test pytest tests/test_helpers.py`)
- [x] New tests for `_collect_openapi_params` body/query coercion (object, array, integer, schema-less)
- [x] New tests for `coerce_value` schema-less JSON detection
- [x] New test for schema preservation on OpenAPI-extracted params
- [x] Fixed 2 pre-existing broken `cache_key_for` tests
- [ ] Manual test with Windmill `run-script-preview-and-wait-result --args '{"key": "value"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)