### PR TITLE
fix: show tool description in per-tool --help output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "3.0.2"
+version = "3.0.3"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2348,14 +2348,15 @@ async def _mcp_session(
     # Handle resource operations
     if resource_action:
         await _handle_resources(
-            session, resource_action, resource_uri, pretty, raw, toon,
+            session, resource_action, resource_uri, pretty, raw, toon, head=head,
         )
         return
 
     # Handle prompt operations
     if prompt_action:
         await _handle_prompts(
-            session, prompt_action, prompt_name, prompt_arguments, pretty, raw, toon,
+            session, prompt_action, prompt_name, prompt_arguments,
+            pretty, raw, toon, head=head,
         )
         return
 
@@ -2407,7 +2408,13 @@ async def _mcp_session(
 
 
 async def _handle_resources(
-    session, action: str, uri: str | None, pretty: bool, raw: bool, toon: bool,
+    session,
+    action: str,
+    uri: str | None,
+    pretty: bool,
+    raw: bool,
+    toon: bool,
+    head: int | None = None,
 ):
     _out = dict(pretty=pretty, raw=raw, toon=toon, head=head)
     if action == "list":

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1875,6 +1875,7 @@ def build_argparse(
         sub = subparsers.add_parser(
             cmd.name,
             help=escape_argparse_help(cmd.description),
+            description=escape_argparse_help(cmd.description),
         )
         sub.set_defaults(_cmd=cmd)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -37,6 +37,11 @@ class TestMCPStdio:
         assert "add-numbers" in r.stdout
         assert "list-items" in r.stdout
 
+    def test_tool_help_shows_description(self):
+        r = self._run("echo", "--help")
+        assert r.returncode == 0
+        assert "Echo back the input" in r.stdout
+
     def test_echo(self):
         r = self._run("echo", "--message", "hello world")
         assert r.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "3.0.1"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Two related fixes to the MCP `--help` and resource/prompt paths.

### 1. Tool description in per-tool `--help` (Fixes #48)

`build_argparse()` only set `help=` on each tool subparser. `help=` controls the one-line summary in the **parent** `--help` listing of subcommands; `description=` is what argparse renders as the body text when running `<tool> --help`. We never passed `description=`, so the tool's description was dropped.

Fix: pass `cmd.description` to both `help=` and `description=` on `subparsers.add_parser()`. Both the live (`@server`) path and the baked-binary path go through `build_argparse()`, so a single change covers both.

### 2. `head` not threaded through to resource/prompt handlers

While running the test suite I noticed 6 pre-existing failures in `tests/test_mcp.py` for `--list-resources`, `--list-resource-templates`, and `--read-resource`. Root cause: `_handle_resources` referenced `head` without declaring it as a parameter, raising `NameError` on every invocation. `_handle_prompts` already accepted `head=` but the caller in `_mcp_session` never forwarded it, silently ignoring the user's `--head` value.

Fix: add `head` to `_handle_resources`'s signature and forward `head=head` to both handlers from `_mcp_session`.

Bumped to `3.0.3`.

## Test plan

- [x] New regression test `test_tool_help_shows_description` asserting the description appears in `<tool> --help` output
- [x] Full `tests/test_mcp.py` suite now passes (36/36) — the 6 resource-related failures are gone
- [x] Manual smoke test: `mcp2cli --mcp-stdio "..." echo --help` now shows `Echo back the input` above the options block
- [x] Parent `--help` (subcommand listing) unchanged — one-line summary still rendered via `help=`