### PR TITLE
fix(oauth): self-heal expired tokens and stale DCR client_id (#50)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "3.0.3"
+version = "3.1.0"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -469,13 +469,21 @@ OAUTH_DIR = CACHE_DIR / "oauth"
 
 
 class FileTokenStorage:
-    """File-based token storage for OAuth tokens and client info."""
+    """File-based token storage for OAuth tokens and client info.
+
+    Persists an absolute ``expires_at`` timestamp alongside ``tokens.json``
+    (in ``tokens_meta.json``) so that on a fresh process the SDK can tell an
+    access token has expired and trigger a refresh, rather than blindly
+    re-sending the stale Bearer and falling through to a full re-auth that
+    reuses a possibly-forgotten DCR client_id (issue #50).
+    """
 
     def __init__(self, server_url: str):
         key = hashlib.sha256(server_url.encode()).hexdigest()[:16]
         self._dir = OAUTH_DIR / key
         self._dir.mkdir(parents=True, exist_ok=True)
         self._tokens_path = self._dir / "tokens.json"
+        self._tokens_meta_path = self._dir / "tokens_meta.json"
         self._client_path = self._dir / "client.json"
 
     async def get_tokens(self):
@@ -491,6 +499,50 @@ class FileTokenStorage:
 
     async def set_tokens(self, tokens) -> None:
         self._tokens_path.write_text(tokens.model_dump_json())
+        # Persist an absolute expiry timestamp so we can detect on a
+        # later process start that the access token has expired.
+        if tokens.expires_in is not None:
+            try:
+                meta = {"expires_at": time.time() + float(tokens.expires_in)}
+                self._tokens_meta_path.write_text(json.dumps(meta))
+            except Exception:
+                pass
+        else:
+            # No expiry info; drop any stale meta sidecar.
+            try:
+                self._tokens_meta_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def get_expires_at(self) -> float | None:
+        """Return the absolute expiry timestamp persisted alongside tokens.
+
+        Returns None when no sidecar exists (older caches or tokens without
+        an ``expires_in`` value).
+        """
+        if not self._tokens_meta_path.exists():
+            return None
+        try:
+            data = json.loads(self._tokens_meta_path.read_text())
+            value = data.get("expires_at")
+            return float(value) if value is not None else None
+        except Exception:
+            return None
+
+    def clear_tokens(self) -> None:
+        """Remove persisted tokens and their expiry sidecar."""
+        for path in (self._tokens_path, self._tokens_meta_path):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def clear_client_info(self) -> None:
+        """Remove persisted DCR client info so a fresh registration runs."""
+        try:
+            self._client_path.unlink()
+        except FileNotFoundError:
+            pass
 
     async def get_client_info(self):
         from mcp.shared.auth import OAuthClientInformationFull
@@ -601,6 +653,53 @@ def build_oauth_provider(
     from mcp.client.auth.oauth2 import OAuthClientProvider
     from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 
+    class _RobustOAuthClientProvider(OAuthClientProvider):
+        """OAuthClientProvider with cross-process expiry + stale-DCR recovery.
+
+        Fixes for issue #50 — Atlassian "Internal Server Error" on next-day
+        OAuth calls. The upstream SDK has two gaps when state is reloaded
+        from disk in a new process:
+
+        1. ``_initialize`` reloads ``current_tokens`` from storage but never
+           recomputes ``token_expiry_time`` from the bare ``OAuthToken``
+           dump (which only carries ``expires_in``). An expired access
+           token therefore looks valid, is sent, and only the 401 fallback
+           runs — skipping the refresh-token grant entirely.
+
+        2. The 401 fallback re-uses the cached DCR ``client_id`` because
+           ``client_info`` was reloaded from disk; if the auth server has
+           since forgotten that registration, ``/authorize`` returns an
+           opaque 500 page rather than a clean ``invalid_client`` redirect
+           and the CLI hangs on the callback.
+
+        We patch both by restoring ``token_expiry_time`` from a sidecar
+        we persist in :class:`FileTokenStorage`, and by wiping the cached
+        ``client_info`` from disk and memory whenever a refresh fails so
+        the subsequent re-auth performs fresh Dynamic Client Registration.
+        """
+
+        async def _initialize(self) -> None:
+            await super()._initialize()
+            storage = self.context.storage
+            if isinstance(storage, FileTokenStorage) and self.context.current_tokens:
+                expires_at = storage.get_expires_at()
+                if expires_at is not None:
+                    self.context.token_expiry_time = expires_at
+
+        async def _handle_refresh_response(self, response) -> bool:
+            ok = await super()._handle_refresh_response(response)
+            if not ok:
+                # Refresh failed. The cached DCR client_id may have been
+                # forgotten by the auth server too; clear it so the
+                # subsequent 401 fallback performs a fresh registration
+                # instead of /authorize?client_id=<stale> → opaque 500.
+                self.context.client_info = None
+                storage = self.context.storage
+                if isinstance(storage, FileTokenStorage):
+                    storage.clear_client_info()
+                    storage.clear_tokens()
+            return ok
+
     _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
     if redirect_uri is not None:
@@ -700,7 +799,7 @@ def build_oauth_provider(
             raise RuntimeError("No authorization code received")
         return (_CallbackHandler.auth_code, _CallbackHandler.state)
 
-    return OAuthClientProvider(
+    return _RobustOAuthClientProvider(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -110,6 +110,196 @@ class TestFileTokenStorage:
 
         anyio.run(_test)
 
+    def test_set_tokens_writes_expires_at_sidecar(self, tmp_path, monkeypatch):
+        """set_tokens persists an absolute expiry timestamp (issue #50)."""
+        import time
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+
+        import anyio
+        from mcp.shared.auth import OAuthToken
+
+        async def _test():
+            before = time.time()
+            token = OAuthToken(
+                access_token="a", token_type="Bearer",
+                refresh_token="r", expires_in=3600,
+            )
+            await storage.set_tokens(token)
+            after = time.time()
+
+            expires_at = storage.get_expires_at()
+            assert expires_at is not None
+            assert before + 3600 - 1 <= expires_at <= after + 3600 + 1
+
+        anyio.run(_test)
+
+    def test_set_tokens_without_expires_in_clears_sidecar(self, tmp_path, monkeypatch):
+        """When expires_in is None, any prior sidecar is removed."""
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+        storage._tokens_meta_path.write_text(json.dumps({"expires_at": 1.0}))
+
+        import anyio
+        from mcp.shared.auth import OAuthToken
+
+        async def _test():
+            await storage.set_tokens(
+                OAuthToken(access_token="a", token_type="Bearer")
+            )
+            assert storage.get_expires_at() is None
+            assert not storage._tokens_meta_path.exists()
+
+        anyio.run(_test)
+
+    def test_get_expires_at_missing_sidecar(self, tmp_path, monkeypatch):
+        """Older caches with no sidecar return None (backward-compat)."""
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+        assert storage.get_expires_at() is None
+
+    def test_clear_client_info_removes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+        storage._client_path.write_text("{}")
+        storage.clear_client_info()
+        assert not storage._client_path.exists()
+        # Idempotent
+        storage.clear_client_info()
+
+    def test_clear_tokens_removes_token_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+        storage._tokens_path.write_text("{}")
+        storage._tokens_meta_path.write_text("{}")
+        storage.clear_tokens()
+        assert not storage._tokens_path.exists()
+        assert not storage._tokens_meta_path.exists()
+
+
+class TestRobustOAuthClientProvider:
+    """Behavior of the _RobustOAuthClientProvider subclass (issue #50)."""
+
+    def test_initialize_restores_token_expiry_from_sidecar(self, tmp_path, monkeypatch):
+        """A fresh process restoring tokens picks up the persisted expiry,
+        so an expired access token correctly fails is_token_valid()."""
+        import time
+        import anyio
+        from mcp.shared.auth import OAuthToken
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+
+        async def _setup():
+            # Persist a token whose expires_in places expiry in the past
+            await storage.set_tokens(
+                OAuthToken(
+                    access_token="stale",
+                    token_type="Bearer",
+                    refresh_token="r",
+                    expires_in=3600,
+                )
+            )
+            # Rewrite the sidecar so expires_at is firmly in the past.
+            storage._tokens_meta_path.write_text(
+                json.dumps({"expires_at": time.time() - 60})
+            )
+
+        anyio.run(_setup)
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://localhost:19881/callback",
+        )
+
+        async def _drive():
+            await provider._initialize()
+            # token_expiry_time must be restored (and in the past)
+            assert provider.context.token_expiry_time is not None
+            assert provider.context.token_expiry_time < time.time()
+            # Therefore the access token is not considered valid …
+            assert not provider.context.is_token_valid()
+            # … but refresh is possible because client_info was pre-seeded
+            # by build_oauth_provider's client_id branch? No — without an
+            # explicit client_id we have no client_info yet, so the SDK
+            # would do a full re-auth. The point of this test is the
+            # expiry restoration; a separate test covers DCR recovery.
+
+        anyio.run(_drive)
+
+    def test_initialize_without_sidecar_leaves_expiry_unset(self, tmp_path, monkeypatch):
+        """Backward compat: caches written by older versions (no sidecar)
+        still load — token_expiry_time stays None (legacy behavior)."""
+        import anyio
+        from mcp.shared.auth import OAuthToken
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+        # Write tokens.json directly (no sidecar) — simulates old cache.
+        storage._tokens_path.write_text(
+            OAuthToken(
+                access_token="a", token_type="Bearer",
+                refresh_token="r", expires_in=3600,
+            ).model_dump_json()
+        )
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://localhost:19882/callback",
+        )
+
+        async def _drive():
+            await provider._initialize()
+            assert provider.context.current_tokens is not None
+            assert provider.context.token_expiry_time is None
+
+        anyio.run(_drive)
+
+    def test_refresh_failure_clears_client_info(self, tmp_path, monkeypatch):
+        """When a refresh response is non-2xx, the cached DCR client_id is
+        cleared so the subsequent re-auth performs fresh registration."""
+        import anyio
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+
+        async def _setup():
+            await storage.set_client_info(
+                OAuthClientInformationFull(
+                    client_id="stale-dcr-id",
+                    redirect_uris=["http://localhost:19883/callback"],
+                )
+            )
+
+        anyio.run(_setup)
+        assert storage._client_path.exists()
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://localhost:19883/callback",
+        )
+
+        # Build a synthetic failed refresh response
+        class _FakeResponse:
+            status_code = 400
+            async def aread(self):
+                return b'{"error":"invalid_grant"}'
+
+        async def _drive():
+            await provider._initialize()
+            provider.context.client_info = await storage.get_client_info()
+            assert provider.context.client_info is not None
+
+            ok = await provider._handle_refresh_response(_FakeResponse())
+            assert ok is False
+            # In-memory and on-disk client_info both cleared
+            assert provider.context.client_info is None
+            assert not storage._client_path.exists()
+
+        anyio.run(_drive)
+
 
 class TestBuildOAuthProvider:
     """Tests for build_oauth_provider factory."""

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "3.0.3"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes #50 — next-day OAuth calls (e.g. against `https://mcp.atlassian.com/v1/sse`) open the browser at `/authorize?client_id=<stale>` and hit an opaque "Internal Server Error" page, with no auto-refresh and no DCR re-registration. The workaround was to `rm -rf ~/.cache/mcp2cli/oauth/<hash>`.

Two upstream SDK gaps were responsible, both reproducible after a fresh process loads cached state from disk:

1. **Lost token expiry across restarts.** `FileTokenStorage` persisted a bare `OAuthToken` dump (which only carries `expires_in`); `_initialize` reloaded the tokens but never recomputed `token_expiry_time`. `is_token_valid()` then returned `True` for an expired access token, the refresh-token grant was skipped, and the request went out with a stale Bearer.
2. **Stale DCR client_id reused on re-auth.** When the inevitable 401 fallback kicked in, the SDK only runs Dynamic Client Registration `if not self.context.client_info` — the cached client_id was reused even after the auth server had forgotten the registration, so `/authorize` returned the generic 500 HTML page.

## Changes

- `FileTokenStorage` now writes a `tokens_meta.json` sidecar with an absolute `expires_at` whenever `set_tokens` runs.
- A small `_RobustOAuthClientProvider` subclass restores `token_expiry_time` from the sidecar in `_initialize`, and clears both in-memory and on-disk `client_info` (plus tokens) whenever `_handle_refresh_response` reports failure — so the next re-auth performs a fresh DCR rather than re-using a forgotten registration.
- Backward compatible: older caches without the sidecar load as before (no recomputed expiry).

## Test plan

- [x] `uv run --extra test pytest tests/test_oauth.py -x` — 43 passed (8 new tests covering the sidecar, expiry restoration, backward-compat, and refresh-failure DCR wipe).
- [x] `uv run --extra test pytest -x` — full suite, 313 passed.