### PR TITLE
feat: add --json flag to force valid JSON output for every command

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,36 @@ mcp2cli @myapi --list --sort alpha
 
 When usage data exists for a source, `--list` defaults to sorting by call frequency. Otherwise insertion order is preserved. Usage data is stored in `~/.cache/mcp2cli/usage.json`.
 
+### JSON output
+
+`--json` forces **valid JSON on stdout for every command**, in every mode. It is the
+machine-readable counterpart to the human-formatted default output, designed for LLM
+agents and scripts that need to parse results reliably.
+
+```bash
+# --list emits a JSON array of command objects (name, description, parameters, ...)
+mcp2cli --mcp https://mcp.example.com/sse --list --json
+mcp2cli --spec ./openapi.json --list --json
+mcp2cli --graphql https://api.example.com/graphql --list --json
+
+# --list --json --compact emits a JSON array of names only
+mcp2cli --mcp https://mcp.example.com/sse --list --json --compact
+
+# MCP tool calls emit the FULL CallToolResult envelope — including
+# structuredContent and isError, not just the flattened text. This surfaces the
+# machine-readable result that modern MCP tools put in structuredContent.
+mcp2cli --mcp https://mcp.example.com/sse --json search --query "test"
+# { "content": [...], "structuredContent": {...}, "isError": false }
+
+# OpenAPI / GraphQL calls emit the response as JSON (non-JSON bodies become a JSON string)
+mcp2cli --spec ./openapi.json --json list-pets
+mcp2cli --graphql https://api.example.com/graphql --json users
+```
+
+`--json` takes precedence over `--raw` and `--toon` (both of which can produce
+non-JSON), so it always wins — that is what makes it a reliable "force JSON" switch.
+Indentation follows the usual rule: pretty on a TTY or with `--pretty`, compact when piped.
+
 ### Output control
 
 ```bash
@@ -289,6 +319,9 @@ Options:
   --fields FIELDS         Override GraphQL selection set (e.g. "id name email")
   --pretty                Pretty-print JSON output
   --raw                   Print raw response body
+  --json                  Force valid JSON output for every command (--list and tool
+                          calls). MCP calls emit the full result envelope including
+                          structuredContent. Takes precedence over --raw and --toon.
   --toon                  Encode output as TOON (token-efficient for LLMs)
   --head N                Limit output to first N records (arrays)
   --version               Show version

--- a/skills/mcp2cli/SKILL.md
+++ b/skills/mcp2cli/SKILL.md
@@ -72,6 +72,8 @@ Options:
   --fields FIELDS         Override GraphQL selection set (e.g. "id name email")
   --pretty                Pretty-print JSON output
   --raw                   Print raw response body
+  --json                  Force valid JSON for every command. --list emits a JSON array;
+                          MCP calls emit the full envelope (structuredContent, isError).
   --toon                  Encode output as TOON (token-efficient for LLMs)
   --head N                Limit output to first N records (arrays)
   --version               Show version

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -277,6 +277,14 @@ def _apply_head(data, n: int):
     return data
 
 
+def _emit_json(data, pretty: bool = False) -> None:
+    """Print *data* as JSON. Indented when *pretty* or stdout is a TTY, else compact."""
+    if pretty or sys.stdout.isatty():
+        print(json.dumps(data, indent=2))
+    else:
+        print(json.dumps(data))
+
+
 def output_result(
     data,
     *,
@@ -284,7 +292,22 @@ def output_result(
     raw: bool = False,
     toon: bool = False,
     head: int | None = None,
+    json_output: bool = False,
 ):
+    # --json forces valid JSON for every command, overriding --raw and --toon
+    # (both of which can produce non-JSON). Strings that contain JSON are
+    # unwrapped; everything else is emitted as a JSON value (e.g. a string
+    # literal for plain prose), guaranteeing parseable stdout.
+    if json_output:
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+        if head is not None:
+            data = _apply_head(data, head)
+        _emit_json(data, pretty)
+        return
     if raw:
         if isinstance(data, str):
             print(data)
@@ -310,10 +333,53 @@ def output_result(
             file=sys.stderr,
         )
         # Fall through to normal output
-    if pretty or sys.stdout.isatty():
-        print(json.dumps(data, indent=2))
+    _emit_json(data, pretty)
+
+
+def _python_type_name(t: type | None) -> str:
+    """Human/JSON-friendly type label for a ParamDef.python_type (None = boolean flag)."""
+    if t is None:
+        return "boolean"
+    return getattr(t, "__name__", str(t))
+
+
+def _param_to_dict(p: "ParamDef") -> dict:
+    d = {
+        "name": p.name,
+        "type": _python_type_name(p.python_type),
+        "required": p.required,
+        "description": p.description,
+        "location": p.location,
+    }
+    if p.choices:
+        d["choices"] = p.choices
+    return d
+
+
+def command_to_dict(cmd: "CommandDef") -> dict:
+    """Serialize a CommandDef to a JSON-friendly dict for `--list --json`."""
+    d: dict = {"name": cmd.name, "description": cmd.description or ""}
+    if cmd.method:
+        d["method"] = cmd.method.upper()
+    if cmd.path:
+        d["path"] = cmd.path
+    if cmd.tool_name:
+        d["toolName"] = cmd.tool_name
+    if cmd.graphql_operation_type:
+        d["operationType"] = cmd.graphql_operation_type
+    d["parameters"] = [_param_to_dict(p) for p in cmd.params]
+    return d
+
+
+def print_commands_json(
+    commands: "list[CommandDef]", compact: bool = False, pretty: bool = False
+) -> None:
+    """Emit a command list as JSON (array of objects, or names when *compact*)."""
+    if compact:
+        payload = [cmd.name for cmd in commands]
     else:
-        print(json.dumps(data))
+        payload = [command_to_dict(cmd) for cmd in commands]
+    _emit_json(payload, pretty)
 
 
 def _build_http_headers(auth_headers: list[tuple[str, str]], multipart: bool = False) -> dict[str, str]:
@@ -1407,9 +1473,15 @@ def list_graphql_commands(
     source_hash: str = "",
     sort_mode: str | None = None,
     top: int | None = None,
+    json_output: bool = False,
+    pretty: bool = False,
 ):
     """Group commands by operation type and print."""
     commands = _apply_list_options(commands, source_hash, sort_mode, top)
+
+    if json_output:
+        print_commands_json(commands, compact=compact, pretty=pretty)
+        return
 
     if compact:
         print(" ".join(cmd.name for cmd in commands))
@@ -1502,6 +1574,7 @@ def execute_graphql(
     fields_override: str | None = None,
     oauth_provider: "httpx.Auth | None" = None,
     head: int | None = None,
+    json_output: bool = False,
 ):
     """Build and execute a GraphQL query/mutation."""
     document, variables, field_name = _build_graphql_document(
@@ -1525,13 +1598,13 @@ def execute_graphql(
             print(f"GraphQL error: {msgs}", file=sys.stderr)
             sys.exit(1)
         # Partial errors — include them in output
-        output_result(result, pretty=pretty, raw=raw, toon=toon, head=head)
+        output_result(result, pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output)
         return
 
     data = result.get("data", {})
     # Extract the specific field's data
     field_data = data.get(field_name, data)
-    output_result(field_data, pretty=pretty, raw=raw, toon=toon, head=head)
+    output_result(field_data, pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output)
 
 
 def handle_graphql(
@@ -1552,6 +1625,7 @@ def handle_graphql(
     sort_mode: str | None = None,
     top: int | None = None,
     compact: bool = False,
+    json_output: bool = False,
 ):
     """Top-level handler for --graphql mode."""
     src_hash = _source_hash_for(url)
@@ -1561,6 +1635,7 @@ def handle_graphql(
     list_kwargs = dict(
         verbose=verbose, compact=compact,
         source_hash=src_hash, sort_mode=sort_mode, top=top,
+        json_output=json_output, pretty=pretty,
     )
 
     if list_mode:
@@ -1568,10 +1643,10 @@ def handle_graphql(
         return
 
     if not remaining:
-        if not compact:
+        if not compact and not json_output:
             print("Available operations:")
         list_graphql_commands(commands, **list_kwargs)
-        if not compact:
+        if not compact and not json_output:
             print("\nUse --list for the same output, or provide a subcommand.")
         return
 
@@ -1587,6 +1662,7 @@ def handle_graphql(
     execute_graphql(
         args, cmd, url, schema, auth_headers, pretty, raw, toon=toon,
         fields_override=fields_override, oauth_provider=oauth_provider,
+        json_output=json_output,
     )
 
     # Record usage after successful execution
@@ -2040,8 +2116,14 @@ def list_openapi_commands(
     source_hash: str = "",
     sort_mode: str | None = None,
     top: int | None = None,
+    json_output: bool = False,
+    pretty: bool = False,
 ):
     commands = _apply_list_options(commands, source_hash, sort_mode, top)
+
+    if json_output:
+        print_commands_json(commands, compact=compact, pretty=pretty)
+        return
 
     if compact:
         print(" ".join(cmd.name for cmd in commands))
@@ -2073,8 +2155,14 @@ def list_mcp_commands(
     source_hash: str = "",
     sort_mode: str | None = None,
     top: int | None = None,
+    json_output: bool = False,
+    pretty: bool = False,
 ):
     commands = _apply_list_options(commands, source_hash, sort_mode, top)
+
+    if json_output:
+        print_commands_json(commands, compact=compact, pretty=pretty)
+        return
 
     if compact:
         print(" ".join(cmd.name for cmd in commands))
@@ -2186,6 +2274,7 @@ def execute_openapi(
     toon: bool = False,
     oauth_provider: "httpx.Auth | None" = None,
     head: int | None = None,
+    json_output: bool = False,
 ):
     path, query_params, extra_headers, body, files = _collect_openapi_params(cmd, args)
     url = base_url.rstrip("/") + path
@@ -2226,6 +2315,14 @@ def execute_openapi(
         if files:
             for _, file_tuple in files.items():
                 file_tuple[1].close()
+
+    if json_output:
+        try:
+            data = resp.json()
+        except Exception:
+            data = resp.text
+        output_result(data, pretty=pretty, head=head, json_output=True)
+        return
 
     if raw:
         sys.stdout.buffer.write(resp.content)
@@ -2271,6 +2368,7 @@ def run_mcp_http(
     top: int | None = None,
     compact: bool = False,
     source_hash: str = "",
+    json_output: bool = False,
 ):
     extra = dict(
         resource_action=resource_action,
@@ -2285,6 +2383,7 @@ def run_mcp_http(
         top=top,
         compact=compact,
         source_hash=source_hash,
+        json_output=json_output,
     )
 
     async def _run():
@@ -2374,6 +2473,7 @@ def run_mcp_stdio(
     top: int | None = None,
     compact: bool = False,
     source_hash: str = "",
+    json_output: bool = False,
 ):
     extra = dict(
         resource_action=resource_action,
@@ -2388,6 +2488,7 @@ def run_mcp_stdio(
         top=top,
         compact=compact,
         source_hash=source_hash,
+        json_output=json_output,
     )
 
     import anyio
@@ -2443,11 +2544,13 @@ async def _mcp_session(
     top: int | None = None,
     compact: bool = False,
     source_hash: str = "",
+    json_output: bool = False,
 ):
     # Handle resource operations
     if resource_action:
         await _handle_resources(
             session, resource_action, resource_uri, pretty, raw, toon, head=head,
+            json_output=json_output,
         )
         return
 
@@ -2455,13 +2558,14 @@ async def _mcp_session(
     if prompt_action:
         await _handle_prompts(
             session, prompt_action, prompt_name, prompt_arguments,
-            pretty, raw, toon, head=head,
+            pretty, raw, toon, head=head, json_output=json_output,
         )
         return
 
     list_kwargs = dict(
         verbose=verbose, compact=compact,
         source_hash=source_hash, sort_mode=sort_mode, top=top,
+        json_output=json_output, pretty=pretty,
     )
 
     if list_mode:
@@ -2478,12 +2582,15 @@ async def _mcp_session(
         if search_pattern:
             commands = _filter_commands(commands, search_pattern)
             if not commands:
-                print(f"\nNo tools matching '{search_pattern}'.")
+                if json_output:
+                    list_mcp_commands(commands, **list_kwargs)
+                else:
+                    print(f"\nNo tools matching '{search_pattern}'.")
                 return
-            if not compact:
+            if not compact and not json_output:
                 print(f"\nTools matching '{search_pattern}':")
         else:
-            if not compact:
+            if not compact and not json_output:
                 print("\nAvailable tools:")
         list_mcp_commands(commands, **list_kwargs)
         return
@@ -2496,6 +2603,12 @@ async def _mcp_session(
         sys.exit(1)
 
     result = await session.call_tool(tool_name, arguments or {})
+
+    if json_output:
+        # Emit the full MCP CallToolResult envelope (content, structuredContent,
+        # isError) using the SDK's own serializer — 100% MCP-compatible.
+        output_result(result.model_dump(mode="json"), pretty=pretty, head=head, json_output=True)
+        return
 
     text = _extract_content_parts(result.content)
     output_result(text, pretty=pretty, raw=raw, toon=toon, head=head)
@@ -2514,8 +2627,9 @@ async def _handle_resources(
     raw: bool,
     toon: bool,
     head: int | None = None,
+    json_output: bool = False,
 ):
-    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head)
+    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output)
     if action == "list":
         result = await session.list_resources()
         data = [
@@ -2568,8 +2682,9 @@ async def _handle_prompts(
     raw: bool,
     toon: bool,
     head: int | None = None,
+    json_output: bool = False,
 ):
-    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head)
+    _out = dict(pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output)
     if action == "list":
         result = await session.list_prompts()
         data = [
@@ -3110,6 +3225,7 @@ def handle_mcp(
     sort_mode: str | None = None,
     top: int | None = None,
     compact: bool = False,
+    json_output: bool = False,
 ):
     # Build a config dict for cache key generation (future-proof)
     config_for_cache = {
@@ -3132,6 +3248,7 @@ def handle_mcp(
             prompt_name=prompt_name,
             prompt_arguments=prompt_arguments,
             head=head,
+            json_output=json_output,
         )
         _dispatch_mcp_call(
             source, is_stdio, auth_headers, env_vars,
@@ -3144,6 +3261,7 @@ def handle_mcp(
     list_kwargs = dict(
         verbose=verbose, compact=compact,
         source_hash=src_hash, sort_mode=sort_mode, top=top,
+        json_output=json_output, pretty=pretty,
     )
 
     if list_mode:
@@ -3157,7 +3275,7 @@ def handle_mcp(
             commands = filter_commands(
                 commands, bake_config.include, bake_config.exclude, bake_config.methods,
             )
-            if not compact:
+            if not compact and not json_output:
                 print("\nAvailable tools:")
             list_mcp_commands(commands, **list_kwargs)
             return
@@ -3169,6 +3287,7 @@ def handle_mcp(
             verbose=verbose,
             sort_mode=sort_mode, top=top, compact=compact,
             source_hash=src_hash,
+            json_output=json_output,
         )
         return
 
@@ -3185,10 +3304,10 @@ def handle_mcp(
         )
 
     if not remaining:
-        if not compact:
+        if not compact and not json_output:
             print("Available tools:")
         list_mcp_commands(commands, **list_kwargs)
-        if not compact:
+        if not compact and not json_output:
             print("\nUse --list for the same output, or provide a subcommand.")
         return
 
@@ -3215,6 +3334,7 @@ def handle_mcp(
         source, is_stdio, auth_headers, env_vars,
         cmd.tool_name, arguments, False, pretty, raw, key, ttl, refresh,
         toon=toon, transport=transport, oauth_provider=oauth_provider,
+        json_output=json_output,
     )
 
     # Record usage after successful execution
@@ -3432,6 +3552,16 @@ def _build_main_parser() -> argparse.ArgumentParser:
     )
     pre.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
     pre.add_argument("--raw", action="store_true", help="Print raw response body")
+    pre.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help=(
+            "Force valid JSON output for every command. --list emits a JSON array of "
+            "commands; MCP tool calls emit the full result envelope including "
+            "structuredContent and isError. Takes precedence over --raw and --toon."
+        ),
+    )
     pre.add_argument(
         "--toon",
         action="store_true",
@@ -3693,32 +3823,28 @@ def _handle_session_operations(
 
     # --- Session client mode ---
     sess_name = pre_args.session
+    _sess_out = dict(
+        pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
+        json_output=pre_args.json_output,
+    )
 
     if pre_args.list_resources:
         result = _session_request(sess_name, "list_resources")
-        output_result(
-            result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-        )
+        output_result(result, **_sess_out)
         return True
     if pre_args.list_resource_templates:
         result = _session_request(sess_name, "list_resource_templates")
-        output_result(
-            result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-        )
+        output_result(result, **_sess_out)
         return True
     if pre_args.read_resource:
         result = _session_request(
             sess_name, "read_resource", {"uri": pre_args.read_resource}
         )
-        output_result(
-            result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-        )
+        output_result(result, **_sess_out)
         return True
     if pre_args.list_prompts:
         result = _session_request(sess_name, "list_prompts")
-        output_result(
-            result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-        )
+        output_result(result, **_sess_out)
         return True
     if pre_args.get_prompt:
         p_args = {}
@@ -3731,9 +3857,7 @@ def _handle_session_operations(
             "get_prompt",
             {"name": pre_args.get_prompt, "arguments": p_args},
         )
-        output_result(
-            result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
-        )
+        output_result(result, **_sess_out)
         return True
     if pre_args.list_commands:
         result = _session_request(sess_name, "list_tools")
@@ -3741,21 +3865,36 @@ def _handle_session_operations(
         if search_pattern:
             commands = _filter_commands(commands, search_pattern)
             if not commands:
-                print(f"\nNo tools matching '{search_pattern}'.")
+                if pre_args.json_output:
+                    list_mcp_commands(
+                        commands, verbose=pre_args.verbose,
+                        json_output=True, pretty=pre_args.pretty,
+                    )
+                else:
+                    print(f"\nNo tools matching '{search_pattern}'.")
                 return True
-            print(f"\nTools matching '{search_pattern}':")
-        else:
+            if not pre_args.json_output:
+                print(f"\nTools matching '{search_pattern}':")
+        elif not pre_args.json_output:
             print("\nAvailable tools:")
-        list_mcp_commands(commands, verbose=pre_args.verbose)
+        list_mcp_commands(
+            commands, verbose=pre_args.verbose,
+            json_output=pre_args.json_output, pretty=pre_args.pretty,
+        )
         return True
 
     # Tool call via session
     if not remaining:
         result = _session_request(sess_name, "list_tools")
         commands = extract_mcp_commands(result)
-        print("Available tools:")
-        list_mcp_commands(commands, verbose=pre_args.verbose)
-        print("\nUse --list for the same output, or provide a subcommand.")
+        if not pre_args.json_output:
+            print("Available tools:")
+        list_mcp_commands(
+            commands, verbose=pre_args.verbose,
+            json_output=pre_args.json_output, pretty=pre_args.pretty,
+        )
+        if not pre_args.json_output:
+            print("\nUse --list for the same output, or provide a subcommand.")
         return True
 
     tools = _session_request(sess_name, "list_tools")
@@ -3781,9 +3920,7 @@ def _handle_session_operations(
     result = _session_request(
         sess_name, "call_tool", {"name": cmd.tool_name, "arguments": arguments}
     )
-    output_result(
-        result, pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon
-    )
+    output_result(result, **_sess_out)
     return True
 
 
@@ -3848,15 +3985,19 @@ def _handle_openapi_mode(
     list_kwargs = dict(
         verbose=pre_args.verbose, compact=pre_args.compact,
         source_hash=src_hash, sort_mode=pre_args.sort_mode, top=pre_args.top,
+        json_output=pre_args.json_output, pretty=pre_args.pretty,
     )
 
     if pre_args.list_commands:
         if search_pattern:
             commands = _filter_commands(commands, search_pattern)
             if not commands:
-                print(f"\nNo tools matching '{search_pattern}'.")
+                if not pre_args.json_output:
+                    print(f"\nNo tools matching '{search_pattern}'.")
+                else:
+                    list_openapi_commands(commands, **list_kwargs)
                 return
-            if not pre_args.compact:
+            if not pre_args.compact and not pre_args.json_output:
                 print(f"\nTools matching '{search_pattern}':")
         list_openapi_commands(commands, **list_kwargs)
         return
@@ -3900,7 +4041,7 @@ def _handle_openapi_mode(
     execute_openapi(
         args, cmd, base_url, auth_headers,
         pre_args.pretty, pre_args.raw, toon=pre_args.toon,
-        oauth_provider=oauth_provider,
+        oauth_provider=oauth_provider, json_output=pre_args.json_output,
     )
 
     # Record usage after successful execution
@@ -3960,6 +4101,7 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
             sort_mode=pre_args.sort_mode,
             top=pre_args.top,
             compact=pre_args.compact,
+            json_output=pre_args.json_output,
         )
         return
 
@@ -3994,6 +4136,7 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
             sort_mode=pre_args.sort_mode,
             top=pre_args.top,
             compact=pre_args.compact,
+            json_output=pre_args.json_output,
         )
         return
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,325 @@
+"""Tests for the --json flag: forces valid JSON output across all modes and paths."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcp2cli import (
+    CommandDef,
+    ParamDef,
+    command_to_dict,
+    output_result,
+    print_commands_json,
+)
+
+MCP_SERVER = str(Path(__file__).parent / "mcp_test_server.py")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: output_result(json_output=True)
+# ---------------------------------------------------------------------------
+
+
+class TestOutputResultJson:
+    def test_dict_emitted_as_json(self, capsys):
+        output_result({"a": 1, "b": [1, 2]}, json_output=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == {"a": 1, "b": [1, 2]}
+
+    def test_json_string_is_unwrapped(self, capsys):
+        # A string that is itself JSON gets parsed, not double-encoded.
+        output_result('{"x": 42}', json_output=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == {"x": 42}
+
+    def test_plain_text_becomes_json_string(self, capsys):
+        # Non-JSON prose is emitted as a valid JSON string literal.
+        output_result("just some prose", json_output=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == "just some prose"
+
+    def test_json_overrides_raw(self, capsys):
+        # --json wins over --raw, still valid JSON.
+        output_result("plain", json_output=True, raw=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == "plain"
+
+    def test_json_overrides_toon(self, capsys):
+        output_result([{"a": 1}], json_output=True, toon=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == [{"a": 1}]
+
+    def test_head_applies_in_json_mode(self, capsys):
+        output_result([1, 2, 3, 4, 5], json_output=True, head=2)
+        out = capsys.readouterr().out
+        assert json.loads(out) == [1, 2]
+
+    def test_pretty_indented(self, capsys):
+        output_result({"a": 1}, json_output=True, pretty=True)
+        out = capsys.readouterr().out
+        assert "\n  " in out
+        assert json.loads(out) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: command serialization
+# ---------------------------------------------------------------------------
+
+
+class TestCommandSerialization:
+    def _cmd(self):
+        return CommandDef(
+            name="list-pets",
+            description="List all pets",
+            method="get",
+            path="/pets",
+            params=[
+                ParamDef(
+                    name="limit",
+                    original_name="limit",
+                    python_type=int,
+                    required=False,
+                    description="Max items",
+                    location="query",
+                    choices=None,
+                ),
+                ParamDef(
+                    name="status",
+                    original_name="status",
+                    python_type=str,
+                    required=True,
+                    description="Filter",
+                    location="query",
+                    choices=["available", "sold"],
+                ),
+            ],
+        )
+
+    def test_command_to_dict_shape(self):
+        d = command_to_dict(self._cmd())
+        assert d["name"] == "list-pets"
+        assert d["description"] == "List all pets"
+        assert d["method"] == "GET"
+        assert d["path"] == "/pets"
+        assert len(d["parameters"]) == 2
+        p0 = d["parameters"][0]
+        assert p0 == {
+            "name": "limit",
+            "type": "int",
+            "required": False,
+            "description": "Max items",
+            "location": "query",
+        }
+        # choices included only when present
+        assert d["parameters"][1]["choices"] == ["available", "sold"]
+
+    def test_boolean_param_type(self):
+        cmd = CommandDef(
+            name="flag-cmd",
+            params=[ParamDef(name="force", original_name="force", python_type=None)],
+        )
+        d = command_to_dict(cmd)
+        assert d["parameters"][0]["type"] == "boolean"
+
+    def test_mcp_command_includes_tool_name(self):
+        cmd = CommandDef(name="echo", tool_name="echo", description="Echo")
+        d = command_to_dict(cmd)
+        assert d["toolName"] == "echo"
+        assert "method" not in d  # mode-specific fields omitted when absent
+
+    def test_graphql_command_includes_operation_type(self):
+        cmd = CommandDef(name="users", graphql_operation_type="query")
+        d = command_to_dict(cmd)
+        assert d["operationType"] == "query"
+
+    def test_print_commands_json_array(self, capsys):
+        print_commands_json([self._cmd()])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert data[0]["name"] == "list-pets"
+
+    def test_print_commands_json_compact_names(self, capsys):
+        print_commands_json([self._cmd()], compact=True)
+        out = capsys.readouterr().out
+        assert json.loads(out) == ["list-pets"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: OpenAPI
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPIJson:
+    def _run(self, petstore_server, *args):
+        cmd = [
+            sys.executable, "-m", "mcp2cli",
+            "--spec", f"{petstore_server}/openapi.json",
+            "--base-url", f"{petstore_server}/api/v1",
+            *args,
+        ]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+
+    def test_list_json(self, petstore_server):
+        r = self._run(petstore_server, "--list", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert isinstance(data, list)
+        names = [c["name"] for c in data]
+        assert "list-pets" in names
+        # each command carries structured parameter metadata
+        listpets = next(c for c in data if c["name"] == "list-pets")
+        assert "parameters" in listpets
+        assert listpets["method"] == "GET"
+
+    def test_list_json_compact(self, petstore_server):
+        r = self._run(petstore_server, "--list", "--json", "--compact")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert isinstance(data, list)
+        assert all(isinstance(name, str) for name in data)
+        assert "list-pets" in data
+
+    def test_call_json(self, petstore_server):
+        r = self._run(petstore_server, "--json", "list-pets")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert isinstance(data, list)
+
+
+# ---------------------------------------------------------------------------
+# Integration: MCP stdio
+# ---------------------------------------------------------------------------
+
+
+class TestMCPStdioJson:
+    def _run(self, *args):
+        cmd = [
+            sys.executable, "-m", "mcp2cli",
+            "--mcp-stdio", f"{sys.executable} {MCP_SERVER}",
+            *args,
+        ]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+    def test_list_json(self):
+        r = self._run("--list", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        names = [c["name"] for c in data]
+        assert "echo" in names
+        assert "add-numbers" in names
+
+    def test_call_json_emits_full_envelope(self):
+        # --json surfaces the full MCP CallToolResult envelope, not just text.
+        r = self._run("--json", "echo", "--message", "hi there")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert isinstance(data, dict)
+        assert data["isError"] is False
+        assert "content" in data
+        texts = [c.get("text") for c in data["content"]]
+        assert "hi there" in texts
+
+    def test_call_json_structured_content_key_present(self):
+        # The envelope always includes the structuredContent key (closing the
+        # gap from the report, even when the value is null for this tool).
+        r = self._run("--json", "add-numbers", "--a", "2", "--b", "3")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert "structuredContent" in data
+        texts = [c.get("text") for c in data["content"]]
+        assert "5" in texts
+
+    def test_json_overrides_raw(self):
+        r = self._run("--json", "--raw", "echo", "--message", "x")
+        assert r.returncode == 0
+        # still a valid JSON envelope despite --raw
+        data = json.loads(r.stdout)
+        assert isinstance(data, dict)
+        assert "content" in data
+
+
+# ---------------------------------------------------------------------------
+# Integration: MCP HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestMCPHttpJson:
+    @pytest.fixture(scope="class")
+    def mcp_http_server(self):
+        import time
+
+        server_script = Path(__file__).parent / "_mcp_http_server.py"
+        proc = subprocess.Popen(
+            [sys.executable, str(server_script)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        port = None
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            line = proc.stdout.readline().strip()
+            if line.startswith("PORT="):
+                port = int(line.split("=")[1])
+                break
+            if proc.poll() is not None:
+                pytest.skip(f"MCP HTTP server failed: {proc.stderr.read()}")
+                return
+        if port is None:
+            proc.kill()
+            pytest.skip("MCP HTTP server did not report port in time")
+            return
+        yield f"http://127.0.0.1:{port}/sse"
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    def _run(self, url, *args):
+        cmd = [sys.executable, "-m", "mcp2cli", "--mcp", url, *args]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+    def test_list_json(self, mcp_http_server):
+        r = self._run(mcp_http_server, "--list", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        names = [c["name"] for c in data]
+        assert "echo" in names
+
+    def test_call_json_envelope(self, mcp_http_server):
+        r = self._run(mcp_http_server, "--json", "echo", "--message", "http json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["isError"] is False
+        texts = [c.get("text") for c in data["content"]]
+        assert "http json" in texts
+
+
+# ---------------------------------------------------------------------------
+# Integration: GraphQL
+# ---------------------------------------------------------------------------
+
+
+def _run_gql(args):
+    cmd = [sys.executable, "-m", "mcp2cli"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+
+class TestGraphQLJson:
+    def test_list_json(self, graphql_server):
+        r = _run_gql(["--graphql", graphql_server, "--list", "--json"])
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        names = [c["name"] for c in data]
+        assert "users" in names
+        users = next(c for c in data if c["name"] == "users")
+        assert users["operationType"] == "query"
+
+    def test_call_json(self, graphql_server):
+        r = _run_gql(["--graphql", graphql_server, "--json", "users"])
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert isinstance(data, list)
+        assert data[0]["name"] == "Alice"


### PR DESCRIPTION
## Summary

Adds a `--json` flag that forces **valid JSON on stdout for every command**, across all
source modes (`--spec`, `--mcp`, `--mcp-stdio`, `--graphql`, `--session`) and every
output path. It's the machine-readable counterpart to the human-formatted default
output — aimed at the LLM-agent / scripting use case mcp2cli is built for.

Motivation: today there is no reliable "give me JSON" switch. `--raw` prints the body
verbatim, the default path only re-serializes payloads that already happen to be JSON
strings, and `--list` always prints a human table. Crucially, MCP tool calls flatten the
result to `.text`/`.data` and **discard `structuredContent` and `isError`** — so the
machine-readable result modern MCP tools return is never surfaced.

## What `--json` does

- **`--list` / `--search`** → a JSON array of command objects: `name`, `description`,
  mode-specific `method`/`path`/`toolName`/`operationType`, and a `parameters` array.
  With `--compact`, a JSON array of names.
- **MCP tool calls** → the full `CallToolResult` envelope via the MCP SDK's own
  `model_dump(mode="json")` — including `content`, `structuredContent`, and `isError`.
  100% MCP-compatible because it's the SDK's own serialization.
- **OpenAPI / GraphQL calls** → the response as JSON; a non-JSON body becomes a JSON
  string so stdout is always parseable.
- **Resources / prompts** → routed through the same JSON emitter.

`--json` takes precedence over `--raw` and `--toon` (both can produce non-JSON), which is
what makes it a dependable "force JSON" switch. Indentation follows the existing
convention (pretty on a TTY or with `--pretty`, compact when piped).

### Example

```console
$ mcp2cli --mcp-stdio "…" --json deploy --env prod --refresh
{
  "meta": null,
  "content": [ { "type": "text", "text": "{\"env\": \"prod\", \"refresh\": true}", … } ],
  "structuredContent": null,
  "isError": false
}
```

## Design / implementation notes

- Surgical and additive: a single `json_output` flag is threaded through existing
  parameters and concentrated in `output_result()` plus a small command-serialization
  helper (`command_to_dict` / `print_commands_json`). No existing behavior changes when
  the flag is absent.
- Human-readable status lines (`Available tools:`, etc.) are suppressed under `--json` so
  stdout stays pure JSON.

## Testing

- New `tests/test_json.py` covers `--list` and tool-call paths for OpenAPI, MCP
  (stdio + HTTP), and GraphQL, plus unit tests for the JSON emitter, flag precedence, and
  command serialization.
- Full suite green: **337 passed** (`uv run pytest tests/`).

## Docs

- README: new "JSON output" section + CLI reference entry.
- Updated the bundled agent skill (`skills/mcp2cli/SKILL.md`) flag reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)