### PR TITLE
fix(oauth): preserve cached client/tokens on transient refresh failure (#59)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "3.3.0"
+version = "3.3.1"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -810,14 +810,52 @@ def build_oauth_provider(
            and the CLI hangs on the callback.
 
         We patch both by restoring ``token_expiry_time`` from a sidecar
-        we persist in :class:`FileTokenStorage`, and by wiping the cached
-        ``client_info`` from disk and memory whenever a refresh fails so
-        the subsequent re-auth performs fresh Dynamic Client Registration.
+        we persist in :class:`FileTokenStorage`, and — only when the token
+        endpoint *definitively* rejects the client or grant — by wiping the
+        cached ``client_info`` from disk and memory so the subsequent re-auth
+        performs fresh Dynamic Client Registration.
+
+        Issue #59: the wipe must NOT fire on a transient refresh failure (a
+        brief 5xx, clock skew, a momentarily-unhappy token endpoint). Erasing
+        ``client.json``/``tokens.json`` on a transient blip forces a full
+        interactive ``authorization_code`` consent on the next call, which
+        permanently bricks any headless/scheduled run that has no browser. We
+        therefore preserve the persisted OAuth state on anything that isn't a
+        clean ``invalid_client``/``invalid_grant`` so a later retry can refresh
+        again on its own.
         """
 
         async def _initialize(self) -> None:
             await super()._initialize()
             _restore_token_expiry_from_sidecar(self.context)
+
+        @staticmethod
+        async def _refresh_failure_is_definitive(response) -> bool:
+            """Return True only when a failed refresh means the cached client
+            or grant is genuinely dead and must be discarded to recover.
+
+            Distinguishes a definitive ``invalid_client`` / ``invalid_grant``
+            rejection (RFC 6749 §5.2) from a transient transport/server error.
+            Returns False — i.e. "keep the persisted state" — for a 5xx, a
+            malformed body, or any other failure a later retry might survive
+            (issue #59).
+            """
+            status = getattr(response, "status_code", None)
+            # Per RFC 6749 §5.2 a 401 from the token endpoint means client
+            # authentication failed (invalid_client) even when the body
+            # carries no machine-readable error code — definitive.
+            if status == 401:
+                return True
+            # Anything that isn't an OAuth 400/401 error response (notably a
+            # 5xx) is transient: keep the cache so the next run can retry.
+            if status != 400:
+                return False
+            try:
+                error = json.loads(await response.aread()).get("error")
+            except Exception:
+                # Unparseable body on a 400 — be conservative and preserve.
+                return False
+            return error in ("invalid_client", "invalid_grant", "unauthorized_client")
 
         async def _handle_refresh_response(self, response) -> bool:
             # Issue #58: RFC 6749 §5.1 permits a refresh response to omit
@@ -832,15 +870,23 @@ def build_oauth_provider(
             )
             ok = await super()._handle_refresh_response(response)
             if not ok:
-                # Refresh failed. The cached DCR client_id may have been
-                # forgotten by the auth server too; clear it so the
-                # subsequent 401 fallback performs a fresh registration
-                # instead of /authorize?client_id=<stale> → opaque 500.
-                self.context.client_info = None
-                storage = self.context.storage
-                if isinstance(storage, FileTokenStorage):
-                    storage.clear_client_info()
-                    storage.clear_tokens()
+                # Refresh failed. Only when the token endpoint *definitively*
+                # rejects us (invalid_client / invalid_grant) do we wipe the
+                # cached DCR client_id + tokens so the subsequent 401 fallback
+                # performs a fresh registration instead of
+                # /authorize?client_id=<stale> → opaque 500 (issue #54).
+                #
+                # A transient failure (5xx, blip, clock skew) must NOT erase
+                # the cache — doing so would force an interactive consent that
+                # no headless/scheduled run can complete (issue #59). Leaving
+                # client.json/tokens.json in place lets the next run simply
+                # retry the refresh.
+                if await self._refresh_failure_is_definitive(response):
+                    self.context.client_info = None
+                    storage = self.context.storage
+                    if isinstance(storage, FileTokenStorage):
+                        storage.clear_client_info()
+                        storage.clear_tokens()
                 return ok
             # Carry the prior refresh token forward when the server did not
             # issue a new one, then re-persist so it survives a restart.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -256,8 +256,8 @@ class TestRobustOAuthClientProvider:
         anyio.run(_drive)
 
     def test_refresh_failure_clears_client_info(self, tmp_path, monkeypatch):
-        """When a refresh response is non-2xx, the cached DCR client_id is
-        cleared so the subsequent re-auth performs fresh registration."""
+        """A definitive invalid_grant rejection clears the cached DCR
+        client_id so the subsequent re-auth performs fresh registration."""
         import anyio
         from mcp.shared.auth import OAuthClientInformationFull
 
@@ -294,6 +294,101 @@ class TestRobustOAuthClientProvider:
             ok = await provider._handle_refresh_response(_FakeResponse())
             assert ok is False
             # In-memory and on-disk client_info both cleared
+            assert provider.context.client_info is None
+            assert not storage._client_path.exists()
+
+        anyio.run(_drive)
+
+    def test_transient_refresh_failure_preserves_cache(self, tmp_path, monkeypatch):
+        """Issue #59: a transient refresh failure (5xx, network blip) must
+        NOT erase client.json/tokens.json, otherwise the next headless run
+        is forced into an interactive consent it can never complete."""
+        import anyio
+        from mcp.shared.auth import OAuthClientInformationFull
+        from mcp.shared.auth import OAuthToken
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+
+        async def _setup():
+            await storage.set_client_info(
+                OAuthClientInformationFull(
+                    client_id="dcr-id",
+                    redirect_uris=["http://localhost:19883/callback"],
+                )
+            )
+            await storage.set_tokens(
+                OAuthToken(
+                    access_token="a",
+                    token_type="Bearer",
+                    refresh_token="r",
+                    expires_in=3600,
+                )
+            )
+
+        anyio.run(_setup)
+        assert storage._client_path.exists()
+        assert storage._tokens_path.exists()
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://localhost:19883/callback",
+        )
+
+        # A 503 from the token endpoint — transient, recoverable on retry.
+        class _FakeResponse:
+            status_code = 503
+            async def aread(self):
+                return b"<html>Service Unavailable</html>"
+
+        async def _drive():
+            await provider._initialize()
+            provider.context.client_info = await storage.get_client_info()
+
+            ok = await provider._handle_refresh_response(_FakeResponse())
+            assert ok is False
+            # Persisted OAuth state survives so a later run can refresh again.
+            assert provider.context.client_info is not None
+            assert storage._client_path.exists()
+            assert storage._tokens_path.exists()
+
+        anyio.run(_drive)
+
+    def test_unauthorized_refresh_failure_clears_cache(self, tmp_path, monkeypatch):
+        """A bare 401 from the token endpoint means client authentication
+        failed (RFC 6749 §5.2) — definitive, so the cache is wiped."""
+        import anyio
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        storage = mcp2cli.FileTokenStorage("https://example.com/mcp")
+
+        async def _setup():
+            await storage.set_client_info(
+                OAuthClientInformationFull(
+                    client_id="stale-dcr-id",
+                    redirect_uris=["http://localhost:19883/callback"],
+                )
+            )
+
+        anyio.run(_setup)
+
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp",
+            redirect_uri="http://localhost:19883/callback",
+        )
+
+        class _FakeResponse:
+            status_code = 401
+            async def aread(self):
+                return b""
+
+        async def _drive():
+            await provider._initialize()
+            provider.context.client_info = await storage.get_client_info()
+
+            ok = await provider._handle_refresh_response(_FakeResponse())
+            assert ok is False
             assert provider.context.client_info is None
             assert not storage._client_path.exists()
 

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fixes #59.

## Problem

`_RobustOAuthClientProvider._handle_refresh_response` deleted **both** the cached DCR client (`client.json`) and tokens (`tokens.json`) on *any* failed refresh. This was intended as the #54 recovery path for a forgotten DCR client, but it treated **every** refresh failure as "the server forgot our client."

A single **transient** failure — a brief 5xx from the token endpoint, a network blip, or clock skew — therefore erased the registration and forced a full interactive `authorization_code` browser consent on the very next call. In any non-interactive context (cron, CI, a scheduled agent) there is no browser to complete that consent, so one transient blip permanently bricked the integration until a human re-consented.

## Fix

Gate the cache wipe on a **definitive** rejection (as suggested in the issue):

- **Wipe** `client.json` + `tokens.json` only when the token endpoint says the client/grant is genuinely dead: HTTP `401` (RFC 6749 §5.2 — client authentication failed), or HTTP `400` with `error ∈ {invalid_client, invalid_grant, unauthorized_client}`.
- **Preserve** the cache on a `5xx`, a malformed body, or any other transient failure — so the next run simply retries the refresh instead of demanding an interactive re-consent it can never complete.

A new `_refresh_failure_is_definitive` helper performs the classification and conservatively defaults to "preserve" on anything unparseable. This keeps the #54 stale-DCR recovery intact while no longer over-firing it.

## Tests

- `test_transient_refresh_failure_preserves_cache` — a 503 keeps both `client.json` and `tokens.json`.
- `test_unauthorized_refresh_failure_clears_cache` — a bare 401 still wipes the cache.
- Existing `test_refresh_failure_clears_client_info` (400 + `invalid_grant`) still passes.

Full suite: **352 passed**. Version bumped to `3.3.1`.

https://claude.ai/code/session_01GKZgbFKHd4HEDfEH8ZurW5