### PR TITLE
fix(bake): use baked tool name and description in help output

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -85,6 +85,8 @@ class BakeConfig:
     include: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     methods: list[str] = field(default_factory=list)
+    name: str | None = None
+    description: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -2187,6 +2189,8 @@ def _run_baked(name: str, argv: list[str]) -> None:
         include=cfg.get("include", []),
         exclude=cfg.get("exclude", []),
         methods=cfg.get("methods", []),
+        name=name,
+        description=cfg.get("description") or None,
     )
     _main_impl(synthetic_argv, bake_config=bake_config)
 
@@ -2197,11 +2201,14 @@ def _run_baked(name: str, argv: list[str]) -> None:
 
 
 def build_argparse(
-    commands: list[CommandDef], pre_parser: argparse.ArgumentParser
+    commands: list[CommandDef],
+    pre_parser: argparse.ArgumentParser,
+    prog: str | None = None,
+    description: str | None = None,
 ) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="mcp2cli",
-        description="Turn any MCP server or OpenAPI spec into a CLI",
+        prog=prog or "mcp2cli",
+        description=description or "Turn any MCP server or OpenAPI spec into a CLI",
         parents=[pre_parser],
     )
     subparsers = parser.add_subparsers(dest="_command")
@@ -3477,7 +3484,12 @@ def handle_mcp(
         return
 
     pre = argparse.ArgumentParser(add_help=False)
-    parser = build_argparse(commands, pre)
+    parser = build_argparse(
+        commands,
+        pre,
+        prog=bake_config.name if bake_config else None,
+        description=bake_config.description if bake_config else None,
+    )
     args = parser.parse_args(remaining)
 
     if not hasattr(args, "_cmd"):
@@ -4195,7 +4207,12 @@ def _handle_openapi_mode(
                 )
                 sys.exit(1)
 
-    parser = build_argparse(commands, pre)
+    parser = build_argparse(
+        commands,
+        pre,
+        prog=bake_config.name if bake_config else None,
+        description=bake_config.description if bake_config else None,
+    )
     args = parser.parse_args(remaining)
 
     if not hasattr(args, "_cmd"):

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -408,6 +408,35 @@ class TestBakeCreateAndUse:
         assert "echo" in r.stdout
         assert "deploy" not in r.stdout
 
+    def test_run_baked_help_shows_name_and_description(self, tmp_path, petstore_server):
+        cfg_dir = tmp_path / "config"
+        cache_dir = tmp_path / "cache"
+        r = _run(
+            "bake", "create", "petstore",
+            "--description", "petstore cli",
+            "--spec", f"{petstore_server}/openapi.json",
+            config_dir=cfg_dir, cache_dir=cache_dir,
+        )
+        assert r.returncode == 0
+
+        r = _run("@petstore", "-h", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert r.returncode == 0
+        assert "usage: petstore" in r.stdout
+        assert "petstore cli" in r.stdout
+
+    def test_run_baked_help_shows_name_without_description(self, tmp_path):
+        cfg_dir = tmp_path / "config"
+        cache_dir = tmp_path / "cache"
+        _run(
+            "bake", "create", "mytools",
+            "--mcp-stdio", f"{sys.executable} {MCP_SERVER}",
+            config_dir=cfg_dir, cache_dir=cache_dir,
+        )
+        r = _run("@mytools", "-h", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert r.returncode == 0
+        assert "usage: mytools" in r.stdout
+        assert "Turn any MCP server or OpenAPI spec into a CLI" in r.stdout
+
     def test_run_baked_nonexistent(self, tmp_path):
         cfg_dir = tmp_path / "config"
         cache_dir = tmp_path / "cache"


### PR DESCRIPTION
## Summary

Use the baked tool's configured `name` and `description` in argparse help output when running `mcp2cli @<name> -h`, instead of always showing the generic `mcp2cli` banner.

## Motivation

Fixes #63

`bake create --description` and `bake update --description` already persist a description into the baked config, but `_run_baked()` never passed it through to the CLI parser. As a result, `mcp2cli @petstore -h` showed `usage: mcp2cli` and the default tagline even when a custom description was configured.

## Changes

- Extend `BakeConfig` with optional `name` and `description` fields
- Populate them in `_run_baked()` from the baked config
- Add optional `prog` / `description` parameters to `build_argparse()`
- Pass baked metadata from `handle_mcp()` and `_handle_openapi_mode()` when building the subcommand parser
- Add integration tests for help output with and without a custom description

## Tests

```bash
python3 -m pytest tests/test_bake.py -q
python3 -m pytest -q
```

Result: **354 passed**

## Notes

- GraphQL and session code paths are unchanged; they do not use `BakeConfig`.
- `bake install` wrappers still exec `mcp2cli @<name>`, so this fix also improves `petstore -h` for installed wrappers.