### PR TITLE
fix(output): emit UTF-8 JSON instead of \u escapes

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -280,9 +280,9 @@ def _apply_head(data, n: int):
 def _emit_json(data, pretty: bool = False) -> None:
     """Print *data* as JSON. Indented when *pretty* or stdout is a TTY, else compact."""
     if pretty or sys.stdout.isatty():
-        print(json.dumps(data, indent=2))
+        print(json.dumps(data, indent=2, ensure_ascii=False))
     else:
-        print(json.dumps(data))
+        print(json.dumps(data, ensure_ascii=False))
 
 
 def output_result(
@@ -312,7 +312,7 @@ def output_result(
         if isinstance(data, str):
             print(data)
         else:
-            print(json.dumps(data))
+            print(json.dumps(data, ensure_ascii=False))
         return
     if isinstance(data, str):
         try:
@@ -323,7 +323,7 @@ def output_result(
     if head is not None:
         data = _apply_head(data, head)
     if toon:
-        encoded = _toon_encode(json.dumps(data))
+        encoded = _toon_encode(json.dumps(data, ensure_ascii=False))
         if encoded is not None:
             print(encoded, end="")
             return
@@ -2093,7 +2093,7 @@ def _bake_show(argv: list[str]) -> None:
             else:
                 masked.append([name, val[:4] + "****" if len(val) > 4 else "****"])
         display["auth_headers"] = masked
-    print(json.dumps(display, indent=2))
+    print(json.dumps(display, indent=2, ensure_ascii=False))
 
 
 def _bake_remove(argv: list[str]) -> None:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -63,6 +63,12 @@ class TestOutputResultJson:
         assert "\n  " in out
         assert json.loads(out) == {"a": 1}
 
+    def test_non_ascii_emitted_as_utf8(self, capsys):
+        output_result({"content": ["返回首页"]}, json_output=True)
+        out = capsys.readouterr().out
+        assert "\\u" not in out
+        assert json.loads(out) == {"content": ["返回首页"]}
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: command serialization


### PR DESCRIPTION
### Summary

Set `ensure_ascii=False` on user-facing `json.dumps()` calls so non-ASCII characters in MCP tool output (CJK, emoji, accented Latin, etc.) are serialized as UTF-8 instead of `\uXXXX` escape sequences.

Fixes #62

### Motivation

Python's default `ensure_ascii=True` expands every non-ASCII character from 1–2 UTF-8 bytes to 6 ASCII bytes (`\uXXXX`). For CJK-heavy MCP tool responses this means 4–6× more tokens when output is consumed by an LLM, plus harder-to-read stdout for debugging.

### Changes

- `_emit_json()` — pretty and compact JSON output paths
- `output_result()` — `--raw` dict fallback and `--toon` pre-encoding
- `_bake_show()` — baked tool config display
- Added `test_non_ascii_emitted_as_utf8` in `tests/test_json.py`

Internal persistence paths (cache, usage tracking, OAuth meta, baked config files, session daemon IPC) are intentionally unchanged to preserve cache-key stability and cross-platform file safety.

### Tests

```
pytest tests/test_json.py — 25/25 passed
```

### Notes

On legacy non-UTF-8 stdout encodings, `print()` could raise `UnicodeEncodeError` where escaped output would not. This trade-off is expected for a CLI targeting UTF-8 JSON consumers and matches the issue intent.