### PR TITLE
fix: handle None inputSchema in extract_mcp_commands

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -845,7 +845,7 @@ def extract_mcp_commands(tools: list[dict]) -> list[CommandDef]:
     for tool in tools:
         name = to_kebab(tool.get("name", "unknown"))
         desc = tool.get("description", "")
-        schema = tool.get("inputSchema", {})
+        schema = tool.get("inputSchema") or {}
         required_fields = set(schema.get("required", []))
         params: list[ParamDef] = []
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -447,6 +447,21 @@ class TestExtractMCPCommands:
         assert cmds[0].name == "list-items"
         assert cmds[0].tool_name == "list_items"
 
+    def test_none_input_schema(self):
+        """Tools with inputSchema=None must not raise AttributeError (GH #41)."""
+        tools = [{"name": "no_schema", "description": "No schema", "inputSchema": None}]
+        cmds = extract_mcp_commands(tools)
+        assert len(cmds) == 1
+        assert cmds[0].name == "no-schema"
+        assert cmds[0].params == []
+
+    def test_missing_input_schema(self):
+        """Tools with no inputSchema key must not raise AttributeError (GH #41)."""
+        tools = [{"name": "no_schema", "description": "No schema"}]
+        cmds = extract_mcp_commands(tools)
+        assert len(cmds) == 1
+        assert cmds[0].params == []
+
 
 class TestSplitAtSubcommand:
     """Tests for _split_at_subcommand() — GH #15."""


### PR DESCRIPTION
## Summary

- Guard against `inputSchema: null` (or missing key) in `extract_mcp_commands`

## Problem

When a non-conformant MCP server returns `null` for `inputSchema`, the call
`tool.get("inputSchema", {})` returns `None` (the key exists, its value is
`None`). The subsequent `schema.get("required", [])` then raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This crashes `mcp2cli --list` (and any other code path that calls
`extract_mcp_commands`) for any server that omits or nullifies `inputSchema`.

## Fix

Change line 848 in `src/mcp2cli/__init__.py` from:

```python
schema = tool.get("inputSchema", {})
```

to:

```python
schema = tool.get("inputSchema") or {}
```

`or {}` treats both a missing key and an explicit `None` value as an empty
schema, so tools without parameters are listed without error.

## Test plan

- [x] `test_none_input_schema` -- tool with `inputSchema=None` produces a `CommandDef` with no params
- [x] `test_missing_input_schema` -- tool with no `inputSchema` key produces a `CommandDef` with no params
- [x] Existing `test_basic` and `test_underscore_to_kebab` continue to pass

Fixes #41