### PR TITLE
fix(deps): cap mcp below 2.0.0 to prevent streamable-http break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "httpx",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",
     "pyyaml",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -452,7 +452,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-asyncio", marker = "extra == 'test'" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Cap the `mcp` dependency at `<2` so fresh installs no longer resolve MCP SDK 2.x, which breaks mcp2cli's streamable-http transport at import time.

## Motivation

Fixes #68. MCP SDK `2.0.0` removed the `streamablehttp_client` alias that mcp2cli imports in three places. Because the published constraint was only `mcp>=1.0`, new `uvx`/CI environments resolve `mcp` 2.x and fail with:

```text
ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'
```

Stdio and SSE paths are unaffected at import time, but streamable-http users lose the transport entirely. With `--transport auto`, the `ImportError` is caught and SSE is attempted instead, producing a misleading `405` from the server.

## Changes

- Update `pyproject.toml`: `mcp>=1.0,<2`
- Regenerate `uv.lock`

Full MCP SDK v2 migration (import renames and runtime surface checks) can be tracked separately.

## Tests

```bash
uv run pytest -q
```

Result: **352 passed**

## Notes

- Dependency-only hotfix; no runtime code changes.
- Reviewed with composer-2.5: **APPROVE**
- A patch release (e.g. `3.3.2`) may be needed after merge so `uvx mcp2cli` picks up the cap.

Fixes #68