### PR TITLE
fix(bake): use baked name and description in help output

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -85,6 +85,18 @@ class BakeConfig:
     include: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     methods: list[str] = field(default_factory=list)
+    prog: str | None = None
+    description: str | None = None
+
+
+_DEFAULT_PARSER_DESCRIPTION = "Turn any MCP server or OpenAPI spec into a CLI"
+
+
+def _parser_branding(bake_config: BakeConfig | None) -> tuple[str, str]:
+    if bake_config is not None and bake_config.prog is not None:
+        description = bake_config.description or _DEFAULT_PARSER_DESCRIPTION
+        return bake_config.prog, description
+    return "mcp2cli", _DEFAULT_PARSER_DESCRIPTION
 
 
 # ---------------------------------------------------------------------------
@@ -2187,6 +2199,8 @@ def _run_baked(name: str, argv: list[str]) -> None:
         include=cfg.get("include", []),
         exclude=cfg.get("exclude", []),
         methods=cfg.get("methods", []),
+        prog=name,
+        description=cfg.get("description"),
     )
     _main_impl(synthetic_argv, bake_config=bake_config)
 
@@ -2197,11 +2211,15 @@ def _run_baked(name: str, argv: list[str]) -> None:
 
 
 def build_argparse(
-    commands: list[CommandDef], pre_parser: argparse.ArgumentParser
+    commands: list[CommandDef],
+    pre_parser: argparse.ArgumentParser,
+    *,
+    prog: str = "mcp2cli",
+    description: str = _DEFAULT_PARSER_DESCRIPTION,
 ) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="mcp2cli",
-        description="Turn any MCP server or OpenAPI spec into a CLI",
+        prog=prog,
+        description=description,
         parents=[pre_parser],
     )
     subparsers = parser.add_subparsers(dest="_command")
@@ -3477,7 +3495,8 @@ def handle_mcp(
         return
 
     pre = argparse.ArgumentParser(add_help=False)
-    parser = build_argparse(commands, pre)
+    prog, description = _parser_branding(bake_config)
+    parser = build_argparse(commands, pre, prog=prog, description=description)
     args = parser.parse_args(remaining)
 
     if not hasattr(args, "_cmd"):
@@ -4195,7 +4214,8 @@ def _handle_openapi_mode(
                 )
                 sys.exit(1)
 
-    parser = build_argparse(commands, pre)
+    prog, description = _parser_branding(bake_config)
+    parser = build_argparse(commands, pre, prog=prog, description=description)
     args = parser.parse_args(remaining)
 
     if not hasattr(args, "_cmd"):

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -17,6 +17,7 @@ from mcp2cli import (
     _load_baked,
     _baked_to_argv,
     _BAKE_NAME_RE,
+    _parser_branding,
 )
 
 MCP_SERVER = str(Path(__file__).parent / "mcp_test_server.py")
@@ -414,6 +415,36 @@ class TestBakeCreateAndUse:
         r = _run("@nope", "--list", config_dir=cfg_dir, cache_dir=cache_dir)
         assert r.returncode != 0
         assert "no baked tool" in r.stderr
+
+    def test_parser_branding_from_bake_config(self):
+        assert _parser_branding(None)[0] == "mcp2cli"
+        cfg = BakeConfig(prog="petstore", description="petstore cli")
+        assert _parser_branding(cfg) == ("petstore", "petstore cli")
+        cfg_default_desc = BakeConfig(prog="petstore")
+        prog, description = _parser_branding(cfg_default_desc)
+        assert prog == "petstore"
+        assert "Turn any MCP server" in description
+
+    def test_baked_help_uses_name_and_description(self, tmp_path, petstore_server):
+        cfg_dir = tmp_path / "config"
+        cache_dir = tmp_path / "cache"
+        r = _run(
+            "bake",
+            "create",
+            "petstore",
+            "--description",
+            "petstore cli",
+            "--spec",
+            f"{petstore_server}/openapi.json",
+            config_dir=cfg_dir,
+            cache_dir=cache_dir,
+        )
+        assert r.returncode == 0
+
+        r = _run("@petstore", "-h", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert r.returncode == 0
+        assert "usage: petstore" in r.stdout
+        assert "petstore cli" in r.stdout
 
     def test_invalid_name_rejected(self, tmp_path):
         cfg_dir = tmp_path / "config"


### PR DESCRIPTION
## Summary

Use the baked tool name and stored `--description` value for top-level argparse branding when running `@name`, so `-h` shows `usage: petstore` and the custom banner instead of the generic `mcp2cli` defaults.

## Motivation

Fixes #63. `bake create/update --description` persisted a description field, but `build_argparse()` always hardcoded `prog="mcp2cli"` and the default tagline.

## Changes

- Extend `BakeConfig` with `prog` and `description`
- Add `_parser_branding()` helper
- Thread branding from `_run_baked` through `handle_mcp` and `_handle_openapi_mode` into `build_argparse()`

## Tests

```bash
python3 -m pytest tests/test_bake.py::TestBakeCreateAndUse::test_parser_branding_from_bake_config tests/test_bake.py::TestBakeCreateAndUse::test_baked_help_uses_name_and_description -v
```

Both pass.

## Notes

- `bake list` description column left out of scope (optional in the issue)
- Reviewed with composer-2.5 before submission

**AI disclosure:** I used AI assistance during implementation and review.

Fixes #63