### PR TITLE
fix: exit non-zero when a tool result has isError=true

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2865,7 +2865,9 @@ def run_mcp_http(
             except Exception:
                 return await _with_sse()
 
-    anyio.run(_run)
+    rc = anyio.run(_run)
+    if rc:
+        sys.exit(rc)
 
 
 def run_mcp_stdio(
@@ -2923,7 +2925,7 @@ def run_mcp_stdio(
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                await _mcp_session(
+                return await _mcp_session(
                     session,
                     tool_name,
                     arguments,
@@ -2937,7 +2939,9 @@ def run_mcp_stdio(
                     **extra,
                 )
 
-    anyio.run(_run)
+    rc = anyio.run(_run)
+    if rc:
+        sys.exit(rc)
 
 
 async def _mcp_session(
@@ -3028,10 +3032,20 @@ async def _mcp_session(
         # isError) with the camelCase wire names, so the envelope does not
         # change shape with the installed SDK major.
         output_result(_mcp_dump(result), pretty=pretty, head=head, json_output=True)
-        return
+        # A failed tool still exits non-zero under --json so callers can detect
+        # it; the envelope on stdout already carries isError for machines.
+        return 1 if _mcp_attr(result, "isError") else 0
 
     text = _extract_content_parts(result.content)
+    if _mcp_attr(result, "isError"):
+        # isError is the MCP signal that the tool failed: report on stderr and
+        # exit non-zero so shell pipelines and CI can detect the failure.
+        # Return the code instead of sys.exit() — a SystemExit raised inside
+        # the anyio task group resurfaces as a BaseExceptionGroup traceback.
+        print(f"Error: {text or f'tool {tool_name!r} reported an error'}", file=sys.stderr)
+        return 1
     output_result(text, pretty=pretty, raw=raw, toon=toon, head=head)
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -3320,7 +3334,10 @@ async def _dispatch_list_tools(session, params):
 
 async def _dispatch_call_tool(session, params):
     result = await session.call_tool(params["name"], params.get("arguments", {}))
-    return _extract_content_parts(result.content)
+    return {
+        "content": _extract_content_parts(result.content),
+        "isError": bool(_mcp_attr(result, "isError")),
+    }
 
 
 async def _dispatch_list_resources(session, params):
@@ -4378,6 +4395,16 @@ def _handle_session_operations(
     result = _session_request(
         sess_name, "call_tool", {"name": cmd.tool_name, "arguments": arguments}
     )
+    if isinstance(result, dict) and "isError" in result:
+        # The daemon reports the tool's isError flag; surface it like the
+        # direct path does: stderr + non-zero exit.
+        if result.get("isError"):
+            print(
+                f"Error: {result.get('content') or f'tool {cmd.tool_name!r} reported an error'}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        result = result["content"]
     output_result(result, **_sess_out)
     return True
 

--- a/tests/_mcp_fixture.py
+++ b/tests/_mcp_fixture.py
@@ -72,6 +72,11 @@ TOOLS = [
             "required": ["env"],
         },
     },
+    {
+        "name": "fail",
+        "description": "Always fails with isError (for exit-code tests)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
 ]
 
 RESOURCES = [
@@ -151,6 +156,8 @@ def _call_tool(name: str, arguments: dict) -> dict:
             "refresh": arguments.get("refresh", False),
         }
         return {"content": [_text(json.dumps(payload))], "isError": False}
+    if name == "fail":
+        return {"content": [_text("boom: deliberate failure")], "isError": True}
     return {"content": [_text(f"Unknown tool: {name}")], "isError": True}
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -168,6 +168,23 @@ class TestMCPStdio:
         r2 = self._run("echo", "--message", "second")
         assert r2.returncode == 0
 
+    # --- Tool failures (isError) ---
+
+    def test_iserror_tool_exits_nonzero(self):
+        """A tool result with isError=true must exit non-zero, on stderr."""
+        r = self._run("fail")
+        assert r.returncode != 0
+        assert "boom: deliberate failure" in r.stderr
+        assert "boom: deliberate failure" not in r.stdout
+
+    def test_iserror_tool_json_keeps_envelope_but_exits_nonzero(self):
+        """--json still emits the full envelope, but the exit code reflects failure."""
+        r = self._run("--json", "fail")
+        assert r.returncode != 0
+        envelope = json.loads(r.stdout)
+        assert envelope["isError"] is True
+        assert envelope["content"][0]["text"] == "boom: deliberate failure"
+
     # --- Resources ---
 
     def test_list_resources(self):
@@ -405,4 +422,62 @@ class TestSessions:
             timeout=10,
         )
         assert name not in r.stdout or "dead" in r.stdout
+
+    def test_session_iserror_tool_exits_nonzero(self):
+        """isError through the session daemon must also exit non-zero."""
+        server = f"{sys.executable} {MCP_SERVER}"
+        name = "test-iserror"
+
+        r = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mcp2cli",
+                "--mcp-stdio",
+                server,
+                "--session-start",
+                name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert r.returncode == 0
+
+        try:
+            r = subprocess.run(
+                [sys.executable, "-m", "mcp2cli", "--session", name, "fail"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode != 0
+            assert "boom: deliberate failure" in r.stderr
+            assert "boom: deliberate failure" not in r.stdout
+
+            # Successful calls still print to stdout and exit 0.
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--session",
+                    name,
+                    "echo",
+                    "--message",
+                    "still fine",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode == 0
+            assert "still fine" in r.stdout
+        finally:
+            subprocess.run(
+                [sys.executable, "-m", "mcp2cli", "--session-stop", name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
 


### PR DESCRIPTION
Fixes #75.

## Problem

A failed tool — `isError: true` on the `CallToolResult`, whether set by the server or produced when the SDK converts a raised exception — was printed to **stdout** with exit **0**. Anything driving mcp2cli non-interactively (shell pipelines, CI, agent wrappers) saw success.

## Fix

- **Direct path** (`_mcp_session`): error text goes to stderr, and the exit code is *returned* through the `anyio.run` boundary rather than raised via `sys.exit()` — a `SystemExit` inside the anyio task group resurfaces as a `BaseExceptionGroup` traceback.
- **`--json`**: still emits the full envelope on stdout (it already carries `isError` for machines), but now also exits 1.
- **Session daemon**: `_dispatch_call_tool` previously dropped the flag entirely (returned only the extracted text). It now returns `{content, isError}`, and the client surfaces the failure the same way as the direct path.

## Verification

New regression tests (all pass):
- `test_iserror_tool_exits_nonzero` — stderr + non-zero exit
- `test_iserror_tool_json_keeps_envelope_but_exits_nonzero` — envelope intact, exit 1
- `test_session_iserror_tool_exits_nonzero` — daemon path fails correctly, successful calls unaffected

Full suite: **385 passed** (382 baseline + 3 new), mcp 1.26 / Python 3.14.

Manual check against a real stdio server returning `isError: true`:

```
$ mcp2cli --mcp-stdio "python server.py" fail
Error: boom: deliberate failure   # stderr
$ echo $?
1
```