### PR TITLE
fix: report connection/auth failures as one clean error line

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2763,6 +2763,44 @@ def execute_openapi(
 # ---------------------------------------------------------------------------
 
 
+def _exc_message(exc: BaseException) -> str:
+    """Flatten an exception — incl. anyio ExceptionGroups — into one message."""
+    nested = getattr(exc, "exceptions", None)
+    if nested:
+        parts = [_exc_message(e) for e in nested]
+        return "; ".join(p for p in parts if p) or exc.__class__.__name__
+    return str(exc) or exc.__class__.__name__
+
+
+def _run_mcp_clean(fn, source: str) -> None:
+    """Run an MCP coroutine, reporting failures as one clean error line.
+
+    Transport failures (bad URL, refused connection, 401/403) otherwise reach
+    the terminal as a multi-level anyio ExceptionGroup traceback with the
+    actual cause buried at the bottom. Set MCP2CLI_DEBUG=1 for the traceback.
+    """
+    try:
+        anyio.run(fn)
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:  # pragma: no cover - interactive only
+        raise
+    except BaseException as exc:
+        if os.environ.get("MCP2CLI_DEBUG"):
+            raise
+        message = _exc_message(exc)
+        lowered = message.lower()
+        if "401" in lowered or "403" in lowered:
+            hint = (
+                " — the server rejected the request; pass credentials with "
+                "--auth-header 'Name:Value' or use the --oauth-* options"
+            )
+        else:
+            hint = ""
+        print(f"Error: cannot use MCP server at {source}: {message}{hint}", file=sys.stderr)
+        sys.exit(1)
+
+
 def run_mcp_http(
     url: str,
     auth_headers: list[tuple[str, str]],
@@ -2865,7 +2903,7 @@ def run_mcp_http(
             except Exception:
                 return await _with_sse()
 
-    anyio.run(_run)
+    _run_mcp_clean(_run, url)
 
 
 def run_mcp_stdio(
@@ -2937,7 +2975,7 @@ def run_mcp_stdio(
                     **extra,
                 )
 
-    anyio.run(_run)
+    _run_mcp_clean(_run, command_str)
 
 
 async def _mcp_session(
@@ -3861,7 +3899,7 @@ def _fetch_mcp_tools(
                 except Exception:
                     await _via_sse()
 
-    anyio.run(_run)
+    _run_mcp_clean(_run, source)
     return tools_result
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -406,3 +406,70 @@ class TestSessions:
         )
         assert name not in r.stdout or "dead" in r.stdout
 
+
+class TestConnectionErrors:
+    """Transport failures must report one clean error line, not a traceback."""
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, "-m", "mcp2cli", *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_unreachable_server_is_one_clean_line(self):
+        r = self._run(
+            "--mcp", "http://127.0.0.1:9/mcp", "--list", "--transport", "streamable"
+        )
+        assert r.returncode != 0
+        assert "Traceback" not in r.stderr
+        assert "Error: cannot use MCP server at http://127.0.0.1:9/mcp" in r.stderr
+        assert r.stdout == ""
+
+    def test_auth_rejection_hints_at_credentials(self):
+        """A 401/403 should suggest --auth-header instead of dumping a traceback."""
+        import http.server
+        import threading
+
+        class Deny(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(401)
+                self.end_headers()
+
+            def do_POST(self):
+                self.send_response(401)
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Deny)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            r = self._run("--mcp", f"http://127.0.0.1:{port}/mcp", "--list")
+            assert r.returncode != 0
+            assert "Traceback" not in r.stderr
+            assert "--auth-header" in r.stderr
+        finally:
+            server.shutdown()
+
+    def test_debug_env_restores_traceback(self):
+        import os
+
+        env = {**os.environ, "MCP2CLI_DEBUG": "1"}
+        r = subprocess.run(
+            [
+                sys.executable, "-m", "mcp2cli",
+                "--mcp", "http://127.0.0.1:9/mcp", "--list",
+                "--transport", "streamable",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert r.returncode != 0
+        assert "Traceback" in r.stderr


### PR DESCRIPTION
Fixes #77.

## Problem

When the MCP server is unreachable or rejects the client (401/403), mcp2cli dumps a multi-screen `BaseExceptionGroup` traceback — nested anyio task-group frames with the actual cause buried at the bottom. The exit code was already non-zero; only the presentation was broken.

Before:

```
$ mcp2cli --mcp http://127.0.0.1:9/mcp --list --transport streamable
  + Exception Group Traceback (most recent call last):
  ... ~40 frames ...
  | httpx.ConnectError: All connection attempts failed
```

After:

```
Error: cannot use MCP server at http://127.0.0.1:9/mcp: All connection attempts failed
```

and on a 401:

```
Error: cannot use MCP server at http://127.0.0.1:8765/mcp: Client error '401 Unauthorized' ... — the server rejected the request; pass credentials with --auth-header 'Name:Value' or use the --oauth-* options
```

## Fix

One small runner, `_run_mcp_clean`, wraps the three user-facing `anyio.run` sites (`run_mcp_http`, `run_mcp_stdio`, `_fetch_mcp_tools`). It flattens exception groups (duck-typed `.exceptions`, so it works on the anyio backport under Python 3.10) into a single stderr line and exits 1. `SystemExit` and `KeyboardInterrupt` pass through untouched.

The session daemon keeps its traceback — it logs to a file where the full stack is useful.

`MCP2CLI_DEBUG=1` restores the traceback for development.

## Verification

New regression tests (all pass):
- `test_unreachable_server_is_one_clean_line` — no traceback, clean stderr, empty stdout
- `test_auth_rejection_hints_at_credentials` — live 401 server, hint present
- `test_debug_env_restores_traceback` — escape hatch works

Full suite: **385 passed** (382 baseline + 3 new), mcp 1.26 / Python 3.14.