### PR TITLE
fix: dedupe kebab-case CLI names so colliding tool names don't brick the CLI

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1494,8 +1494,19 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
 
 def extract_mcp_commands(tools: list[dict]) -> list[CommandDef]:
     commands: list[CommandDef] = []
+    used_names: set[str] = set()
     for tool in tools:
         name = to_kebab(tool.get("name", "unknown"))
+        # Two tools can kebab-case to the same CLI name (get_user + getUser).
+        # argparse raises "conflicting subparser" and bricks the whole CLI, so
+        # de-duplicate here; the original name is still sent on the wire via
+        # tool_name.
+        if name in used_names:
+            suffix = 2
+            while f"{name}-{suffix}" in used_names:
+                suffix += 1
+            name = f"{name}-{suffix}"
+        used_names.add(name)
         desc = tool.get("description", "")
         schema = tool.get("inputSchema", {})
         required_fields = set(schema.get("required", []))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -425,6 +425,20 @@ class TestExtractMCPCommands:
         assert cmds[0].name == "list-items"
         assert cmds[0].tool_name == "list_items"
 
+    def test_kebab_collision_deduplicated(self):
+        """get_user + getUser both kebab to get-user; argparse would raise
+        'conflicting subparser' and brick the CLI. Names must be unique while
+        tool_name keeps the original wire name."""
+        tools = [
+            {"name": "get_user", "description": "snake", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "getUser", "description": "camel", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "get-user", "description": "kebab", "inputSchema": {"type": "object", "properties": {}}},
+        ]
+        cmds = extract_mcp_commands(tools)
+        names = [c.name for c in cmds]
+        assert len(set(names)) == 3
+        assert [c.tool_name for c in cmds] == ["get_user", "getUser", "get-user"]
+
 
 class TestSplitAtSubcommand:
     """Tests for _split_at_subcommand() — GH #15."""


### PR DESCRIPTION
Fixes #79

## Problem
Two tools that kebab-case to the same CLI name (`get_user` + `getUser` → `get-user`) make `subparsers.add_parser()` raise `ValueError: conflicting subparser` during parser construction — every invocation fails, including `--list` and `--help`.

## Fix
De-duplicate CLI names with a `-2`/`-3` suffix in `extract_mcp_commands()`. The wire name sent in `tools/call` already comes from `CommandDef.tool_name` (the original server name), so nothing changes on the wire.

## Verification
- New unit test `test_kebab_collision_deduplicated` (3-way collision: `get_user`, `getUser`, `get-user`)
- Live probe: stdio server with both tools — `get-user --id x` calls `get_user`, `get-user-2 --id y` calls `getUser`
- Full suite: 369 passed (368 baseline + 1 new)