### PR TITLE
fix: rename tool flags that collide with argparse/mcp2cli reserved names

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1934,7 +1934,7 @@ def _build_graphql_document(
     types_by_name = {t["name"]: t for t in schema.get("types", []) if t.get("name")}
 
     # Build variables dict from args
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         variables = read_stdin_json("GraphQL variables")
     else:
         variables = {}
@@ -2486,6 +2486,14 @@ def build_argparse(
         seen_flags: set[str] = set()
         for p in cmd.params:
             flag = f"--{p.name}"
+            # argparse owns --help on every subparser and mcp2cli owns --stdin;
+            # a tool property with one of these names raised "conflicting option
+            # string" while building the parser, which killed *every* command on
+            # that server, not just the offending tool. Rename the flag but pin
+            # dest so argument collection (getattr(args, p.name)) still finds it.
+            renamed = p.name in ("help", "stdin")
+            if renamed:
+                flag = f"--arg-{p.name}"
             if flag in seen_flags:
                 continue  # skip duplicate param names (e.g. path + body both have same name)
             seen_flags.add(flag)
@@ -2506,6 +2514,8 @@ def build_argparse(
             kwargs["help"] = escape_argparse_help(p.description)
             if p.choices:
                 kwargs["choices"] = p.choices
+            if renamed:
+                kwargs["dest"] = p.name.replace("-", "_")
             sub.add_argument(flag, **kwargs)
 
     return parser
@@ -2648,7 +2658,7 @@ def _collect_openapi_params(
             elif p.location == "header":
                 extra_headers[p.original_name] = str(val)
     else:
-        if getattr(args, "stdin", False):
+        if getattr(args, "stdin", False) is True:
             body = read_stdin_json("OpenAPI request body")
         else:
             body = {}
@@ -3772,7 +3782,7 @@ def handle_mcp(
 
     cmd: CommandDef = args._cmd
 
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         arguments = read_stdin_json("MCP tool arguments")
     else:
         arguments = {}
@@ -4366,7 +4376,7 @@ def _handle_session_operations(
         sys.exit(1)
 
     cmd: CommandDef = args._cmd
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         arguments = read_stdin_json(f"session {sess_name} tool arguments")
     else:
         arguments = {}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -426,6 +426,37 @@ class TestExtractMCPCommands:
         assert cmds[0].tool_name == "list_items"
 
 
+class TestBuildArgparseReservedFlags:
+    """A tool property named help/stdin used to raise 'conflicting option
+    string' during parser build, killing every command on that server."""
+
+    def _build(self, props):
+        from mcp2cli import build_argparse
+
+        tools = [
+            {
+                "name": "weird",
+                "description": "reserved props",
+                "inputSchema": {"type": "object", "properties": props},
+            }
+        ]
+        pre = argparse.ArgumentParser(add_help=False)
+        return build_argparse(extract_mcp_commands(tools), pre)
+
+    def test_help_property_does_not_brick_parser(self):
+        parser = self._build({"help": {"type": "string"}})
+        args = parser.parse_args(["weird", "--arg-help", "h1"])
+        assert args.help == "h1"
+
+    def test_stdin_property_does_not_brick_parser_or_trigger_stdin_mode(self):
+        parser = self._build({"stdin": {"type": "string"}})
+        args = parser.parse_args(["weird", "--arg-stdin", "s1"])
+        assert args.stdin == "s1"  # value, not True -> stdin mode not triggered
+        # built-in --stdin still works
+        args2 = parser.parse_args(["weird", "--stdin"])
+        assert args2.stdin is True
+
+
 class TestSplitAtSubcommand:
     """Tests for _split_at_subcommand() — GH #15."""
 


### PR DESCRIPTION
Fixes #81

## Problem
A tool input property named `help` or `stdin` makes `sub.add_argument()` raise `conflicting option string` during parser construction — argparse owns `--help` on every subparser and mcp2cli owns `--stdin`. Every invocation against that server fails, including `--list` and `--help`.

## Fix
Rename the colliding flag to `--arg-help` / `--arg-stdin` but pin `dest` to the original property name, so argument collection (`getattr(args, p.name.replace('-','_'))`) still finds the value and it reaches the tool call under its original name. Also tighten the four stdin-mode checks to `is True` so a tool property named `stdin` (a string value) can't falsely trigger stdin JSON mode.

## Verification
- New unit tests `TestBuildArgparseReservedFlags` (help + stdin props, and built-in `--stdin` still works)
- Live probe: stdio server with a `weird` tool — `weird --arg-help h1 --arg-stdin s1` → `{"help": "h1", "stdin": "s1"}`; `weird --help` prints help normally
- Full suite: 370 passed (368 baseline + 2 new)