### PR TITLE
fix: infer argparse type from enum values when schema has no type

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -190,6 +190,16 @@ def schema_type_to_python(schema: dict) -> tuple[type | None, str]:
         return str, " (JSON array)"
     if t == "object":
         return str, " (JSON object)"
+    if t is None:
+        # No "type" but an enum: infer the argparse type from the values, so
+        # numeric enums stay callable (otherwise argparse parses the flag as a
+        # string and rejects it against numeric choices).
+        enum = schema.get("enum")
+        if enum and not any(isinstance(v, bool) for v in enum):
+            if all(isinstance(v, int) for v in enum):
+                return int, ""
+            if all(isinstance(v, (int, float)) for v in enum):
+                return float, ""
     return str, ""
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -53,6 +53,21 @@ class TestSchemaTypeToPython:
     def test_missing_type(self):
         assert schema_type_to_python({}) == (str, "")
 
+    def test_missing_type_int_enum_inferred(self):
+        # No "type" but a numeric enum: argparse must parse the flag as int or
+        # it rejects the value against numeric choices.
+        assert schema_type_to_python({"enum": [1, 2, 3]}) == (int, "")
+
+    def test_missing_type_float_enum_inferred(self):
+        assert schema_type_to_python({"enum": [0.5, 1.5]}) == (float, "")
+
+    def test_missing_type_string_enum_stays_str(self):
+        assert schema_type_to_python({"enum": ["a", "b"]}) == (str, "")
+
+    def test_missing_type_bool_enum_not_inferred(self):
+        # bool is a subclass of int; don't misread a bool enum as int
+        assert schema_type_to_python({"enum": [True, False]}) == (str, "")
+
 
 class TestCoerceValue:
     def test_none(self):


### PR DESCRIPTION
Fixes #83

## Problem
A numeric `enum` without a `type` key is legal JSON Schema, but `schema_type_to_python()` returns `str` whenever `type` is missing — argparse then parses the flag as a string and rejects every value against the numeric choices (`invalid choice: '2' (choose from '1', '2', '3')`). The tool is uncallable.

## Fix
When `type` is absent, infer the argparse type from the enum values: all-int → `int`, all-numeric → `float`. Bool enums are explicitly excluded (bool is a subclass of int).

## Verification
- 4 new unit tests (int enum, float enum, string enum unchanged, bool enum not misread)
- Live probe: `set-level --level 2` → server receives `level_type=int value=2`
- Full suite: 372 passed (368 baseline + 4 new)