### PR TITLE
fix: normalize array-form JSON Schema types (e.g. ["integer", "null"])

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -178,8 +178,17 @@ def read_stdin_json(context: str):
         sys.exit(1)
 
 
+def _normalize_schema_type(t):
+    """JSON Schema allows "type": ["integer", "null"] (array form). Reduce it
+    to the single concrete type, dropping "null"; anything else passes through."""
+    if isinstance(t, list):
+        concrete = [x for x in t if x != "null"]
+        return concrete[0] if len(concrete) == 1 else None
+    return t
+
+
 def schema_type_to_python(schema: dict) -> tuple[type | None, str]:
-    t = schema.get("type")
+    t = _normalize_schema_type(schema.get("type"))
     if t == "integer":
         return int, ""
     if t == "number":
@@ -207,7 +216,7 @@ def _coerce_item(value: str, item_type: str | None):
 def coerce_value(value, schema: dict):
     if value is None:
         return None
-    t = schema.get("type")
+    t = _normalize_schema_type(schema.get("type"))
     if t == "array":
         if isinstance(value, list):
             return value
@@ -218,7 +227,7 @@ def coerce_value(value, schema: dict):
                     return parsed
             except (json.JSONDecodeError, TypeError):
                 pass
-            item_type = schema.get("items", {}).get("type")
+            item_type = _normalize_schema_type(schema.get("items", {}).get("type"))
             if "," in value:
                 return [_coerce_item(v.strip(), item_type) for v in value.split(",")]
             return [_coerce_item(value, item_type)]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -53,6 +53,12 @@ class TestSchemaTypeToPython:
     def test_missing_type(self):
         assert schema_type_to_python({}) == (str, "")
 
+    def test_union_type_array_form(self):
+        # JSON Schema allows "type": ["integer", "null"]
+        assert schema_type_to_python({"type": ["integer", "null"]}) == (int, "")
+        assert schema_type_to_python({"type": ["number", "null"]}) == (float, "")
+        assert schema_type_to_python({"type": ["string", "null"]}) == (str, "")
+
 
 class TestCoerceValue:
     def test_none(self):
@@ -63,6 +69,11 @@ class TestCoerceValue:
 
     def test_number(self):
         assert coerce_value("3.14", {"type": "number"}) == 3.14
+
+    def test_union_type_array_form(self):
+        # "type": ["integer", "null"] must still coerce to int
+        assert coerce_value("42", {"type": ["integer", "null"]}) == 42
+        assert coerce_value("3.14", {"type": ["number", "null"]}) == 3.14
 
     def test_boolean(self):
         assert coerce_value(True, {"type": "boolean"}) is True


### PR DESCRIPTION
Fixes #85

## Problem
JSON Schema allows `"type": ["integer", "null"]`. Both `schema_type_to_python()` and `coerce_value()` compare `t == "integer"`, which fails on a list — the value is treated as a string end to end and the tool receives `"5"` instead of `5`.

## Fix
Add `_normalize_schema_type()`: reduce the array form to its single concrete type, dropping `null`. Applied in `schema_type_to_python()`, `coerce_value()`, and the array `items` type.

## Verification
- New unit tests for both functions (int/number/string union forms)
- Live probe: `union-tool --count 5` → server receives `count_type=int value=5`
- Full suite: 370 passed (368 baseline + 2 new)