### PR TITLE
fix: render resource_link blocks instead of dropping them

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -3280,13 +3280,23 @@ def session_start(
 
 
 def _extract_content_parts(content_list, *, attrs=("text", "data")) -> str:
-    """Extract text/data/blob from MCP content objects, joined by newline."""
+    """Extract text/data/blob from MCP content objects, joined by newline.
+
+    ``resource_link`` blocks carry neither ``text`` nor ``data`` — only
+    ``uri``/``name`` — so they used to be dropped silently. Render them as
+    ``name: uri`` (or just the URI) instead.
+    """
     parts = []
     for c in content_list:
         for attr in attrs:
             if hasattr(c, attr):
                 parts.append(getattr(c, attr))
                 break
+        else:
+            uri = getattr(c, "uri", None)
+            if uri is not None:
+                name = getattr(c, "name", None)
+                parts.append(f"{name}: {uri}" if name else str(uri))
     return "\n".join(parts) if parts else ""
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,6 +10,7 @@ from mcp2cli import (
     CommandDef,
     _apply_head,
     _collect_openapi_params,
+    _extract_content_parts,
     _find_toon_cli,
     _list_all_tools,
     _split_at_subcommand,
@@ -667,3 +668,19 @@ class TestListAllTools:
         session = _FakeSession([(None, _FakePage([], next_cursor=None))])
         tools = asyncio.run(_list_all_tools(session))
         assert tools == []
+
+
+class TestExtractContentParts:
+    def test_resource_link_block_is_rendered(self):
+        """resource_link blocks carry only uri/name and must not be dropped."""
+        from types import SimpleNamespace
+
+        text_block = SimpleNamespace(text="see:")
+        link = SimpleNamespace(uri="probe://linked", name="linked-doc")
+        assert _extract_content_parts([text_block, link]) == "see:\nlinked-doc: probe://linked"
+
+    def test_resource_link_without_name(self):
+        from types import SimpleNamespace
+
+        link = SimpleNamespace(uri="probe://linked")
+        assert _extract_content_parts([link]) == "probe://linked"


### PR DESCRIPTION
Fixes #89

## Problem
`_extract_content_parts` only reads `text`/`data` attributes. A `resource_link` block carries neither — only `uri`/`name` — so it is silently dropped from non-`--json` tool output.

## Fix
In the shared `_extract_content_parts`, fall back to rendering `uri` (prefixed with `name:` when present) for blocks that match no configured attribute. Fixes both the CLI output path and `_dispatch_call_tool` in one place.

## Verification
- Live probe: `with-link` now prints `see:` + `linked-doc: probe://linked`
- New unit tests in `test_helpers.py` (with and without `name`)
- Full suite: 370 passed (368 baseline + 2 new)