### PR TITLE
fix: stop --toon from silently installing the TOON CLI over the network

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,13 @@ jobs:
       - run: uv pip install -e . --no-deps
       - run: uv pip install "${{ matrix.mcp }}" httpx pyyaml pytest pytest-asyncio tiktoken
 
+      # The --toon tests assert real encoder output. Installing the CLI here
+      # puts `toon` on PATH, so they exercise it deterministically instead of
+      # relying on npx fetching the package mid-test: runners ship npx but not
+      # the package, and that implicit download raced _toon_encode's 10s
+      # timeout — 5 matrix jobs won it, 1 lost, so main went red at random.
+      - run: npm install -g @toon-format/cli
+
       - name: Report resolved versions
         run: .venv/bin/python -c "import importlib.metadata as m; print('mcp', m.version('mcp'))"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "3.5.0"
+version = "3.6.0"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2905,7 +2905,9 @@ def run_mcp_http(
             except Exception:
                 return await _with_sse()
 
-    anyio.run(_run)
+    rc = anyio.run(_run)
+    if rc:
+        sys.exit(rc)
 
 
 def run_mcp_stdio(
@@ -2963,7 +2965,7 @@ def run_mcp_stdio(
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                await _mcp_session(
+                return await _mcp_session(
                     session,
                     tool_name,
                     arguments,
@@ -2977,7 +2979,9 @@ def run_mcp_stdio(
                     **extra,
                 )
 
-    anyio.run(_run)
+    rc = anyio.run(_run)
+    if rc:
+        sys.exit(rc)
 
 
 async def _mcp_session(
@@ -3068,10 +3072,20 @@ async def _mcp_session(
         # isError) with the camelCase wire names, so the envelope does not
         # change shape with the installed SDK major.
         output_result(_mcp_dump(result), pretty=pretty, head=head, json_output=True)
-        return
+        # A failed tool still exits non-zero under --json so callers can detect
+        # it; the envelope on stdout already carries isError for machines.
+        return 1 if _mcp_attr(result, "isError") else 0
 
     text = _extract_content_parts(result.content)
+    if _mcp_attr(result, "isError"):
+        # isError is the MCP signal that the tool failed: report on stderr and
+        # exit non-zero so shell pipelines and CI can detect the failure.
+        # Return the code instead of sys.exit() — a SystemExit raised inside
+        # the anyio task group resurfaces as a BaseExceptionGroup traceback.
+        print(f"Error: {text or f'tool {tool_name!r} reported an error'}", file=sys.stderr)
+        return 1
     output_result(text, pretty=pretty, raw=raw, toon=toon, head=head)
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -3370,7 +3384,10 @@ async def _dispatch_list_tools(session, params):
 
 async def _dispatch_call_tool(session, params):
     result = await session.call_tool(params["name"], params.get("arguments", {}))
-    return _extract_content_parts(result.content)
+    return {
+        "content": _extract_content_parts(result.content),
+        "isError": bool(_mcp_attr(result, "isError")),
+    }
 
 
 async def _dispatch_list_resources(session, params):
@@ -4428,6 +4445,16 @@ def _handle_session_operations(
     result = _session_request(
         sess_name, "call_tool", {"name": cmd.tool_name, "arguments": arguments}
     )
+    if isinstance(result, dict) and "isError" in result:
+        # The daemon reports the tool's isError flag; surface it like the
+        # direct path does: stderr + non-zero exit.
+        if result.get("isError"):
+            print(
+                f"Error: {result.get('content') or f'tool {cmd.tool_name!r} reported an error'}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        result = result["content"]
     output_result(result, **_sess_out)
     return True
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2803,6 +2803,44 @@ def execute_openapi(
 # ---------------------------------------------------------------------------
 
 
+def _exc_message(exc: BaseException) -> str:
+    """Flatten an exception — incl. anyio ExceptionGroups — into one message."""
+    nested = getattr(exc, "exceptions", None)
+    if nested:
+        parts = [_exc_message(e) for e in nested]
+        return "; ".join(p for p in parts if p) or exc.__class__.__name__
+    return str(exc) or exc.__class__.__name__
+
+
+def _run_mcp_clean(fn, source: str):
+    """Run an MCP coroutine, reporting failures as one clean error line.
+
+    Transport failures (bad URL, refused connection, 401/403) otherwise reach
+    the terminal as a multi-level anyio ExceptionGroup traceback with the
+    actual cause buried at the bottom. Set MCP2CLI_DEBUG=1 for the traceback.
+    """
+    try:
+        return anyio.run(fn)
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:  # pragma: no cover - interactive only
+        raise
+    except BaseException as exc:
+        if os.environ.get("MCP2CLI_DEBUG"):
+            raise
+        message = _exc_message(exc)
+        lowered = message.lower()
+        if "401" in lowered or "403" in lowered:
+            hint = (
+                " — the server rejected the request; pass credentials with "
+                "--auth-header 'Name:Value' or use the --oauth-* options"
+            )
+        else:
+            hint = ""
+        print(f"Error: cannot use MCP server at {source}: {message}{hint}", file=sys.stderr)
+        sys.exit(1)
+
+
 def run_mcp_http(
     url: str,
     auth_headers: list[tuple[str, str]],
@@ -2905,7 +2943,7 @@ def run_mcp_http(
             except Exception:
                 return await _with_sse()
 
-    rc = anyio.run(_run)
+    rc = _run_mcp_clean(_run, url)
     if rc:
         sys.exit(rc)
 
@@ -2979,7 +3017,7 @@ def run_mcp_stdio(
                     **extra,
                 )
 
-    rc = anyio.run(_run)
+    rc = _run_mcp_clean(_run, command_str)
     if rc:
         sys.exit(rc)
 
@@ -3928,7 +3966,7 @@ def _fetch_mcp_tools(
                 except Exception:
                     await _via_sse()
 
-    anyio.run(_run)
+    _run_mcp_clean(_run, source)
     return tools_result
 
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -199,6 +199,16 @@ def schema_type_to_python(schema: dict) -> tuple[type | None, str]:
         return str, " (JSON array)"
     if t == "object":
         return str, " (JSON object)"
+    if t is None:
+        # No "type" but an enum: infer the argparse type from the values, so
+        # numeric enums stay callable (otherwise argparse parses the flag as a
+        # string and rejects it against numeric choices).
+        enum = schema.get("enum")
+        if enum and not any(isinstance(v, bool) for v in enum):
+            if all(isinstance(v, int) for v in enum):
+                return int, ""
+            if all(isinstance(v, (int, float)) for v in enum):
+                return float, ""
     return str, ""
 
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -3280,13 +3280,23 @@ def session_start(
 
 
 def _extract_content_parts(content_list, *, attrs=("text", "data")) -> str:
-    """Extract text/data/blob from MCP content objects, joined by newline."""
+    """Extract text/data/blob from MCP content objects, joined by newline.
+
+    ``resource_link`` blocks carry neither ``text`` nor ``data`` — only
+    ``uri``/``name`` — so they used to be dropped silently. Render them as
+    ``name: uri`` (or just the URI) instead.
+    """
     parts = []
     for c in content_list:
         for attr in attrs:
             if hasattr(c, attr):
                 parts.append(getattr(c, attr))
                 break
+        else:
+            uri = getattr(c, "uri", None)
+            if uri is not None:
+                name = getattr(c, "name", None)
+                parts.append(f"{name}: {uri}" if name else str(uri))
     return "\n".join(parts) if parts else ""
 
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1945,7 +1945,7 @@ def _build_graphql_document(
     types_by_name = {t["name"]: t for t in schema.get("types", []) if t.get("name")}
 
     # Build variables dict from args
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         variables = read_stdin_json("GraphQL variables")
     else:
         variables = {}
@@ -2497,6 +2497,14 @@ def build_argparse(
         seen_flags: set[str] = set()
         for p in cmd.params:
             flag = f"--{p.name}"
+            # argparse owns --help on every subparser and mcp2cli owns --stdin;
+            # a tool property with one of these names raised "conflicting option
+            # string" while building the parser, which killed *every* command on
+            # that server, not just the offending tool. Rename the flag but pin
+            # dest so argument collection (getattr(args, p.name)) still finds it.
+            renamed = p.name in ("help", "stdin")
+            if renamed:
+                flag = f"--arg-{p.name}"
             if flag in seen_flags:
                 continue  # skip duplicate param names (e.g. path + body both have same name)
             seen_flags.add(flag)
@@ -2517,6 +2525,8 @@ def build_argparse(
             kwargs["help"] = escape_argparse_help(p.description)
             if p.choices:
                 kwargs["choices"] = p.choices
+            if renamed:
+                kwargs["dest"] = p.name.replace("-", "_")
             sub.add_argument(flag, **kwargs)
 
     return parser
@@ -2659,7 +2669,7 @@ def _collect_openapi_params(
             elif p.location == "header":
                 extra_headers[p.original_name] = str(val)
     else:
-        if getattr(args, "stdin", False):
+        if getattr(args, "stdin", False) is True:
             body = read_stdin_json("OpenAPI request body")
         else:
             body = {}
@@ -3793,7 +3803,7 @@ def handle_mcp(
 
     cmd: CommandDef = args._cmd
 
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         arguments = read_stdin_json("MCP tool arguments")
     else:
         arguments = {}
@@ -4387,7 +4397,7 @@ def _handle_session_operations(
         sys.exit(1)
 
     cmd: CommandDef = args._cmd
-    if getattr(args, "stdin", False):
+    if getattr(args, "stdin", False) is True:
         arguments = read_stdin_json(f"session {sess_name} tool arguments")
     else:
         arguments = {}

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -61,6 +61,7 @@ class ParamDef:
     choices: list | None = None
     location: str = "body"  # path|query|header|body|tool_input
     schema: dict = field(default_factory=dict)
+    cli_name: str | None = None  # collision-free argparse flag name
 
 
 @dataclass
@@ -518,9 +519,34 @@ def _python_type_name(t: type | None) -> str:
     return getattr(t, "__name__", str(t))
 
 
+def _param_dest(p: "ParamDef") -> str:
+    """Return the argparse destination allocated for a parameter."""
+    return (p.cli_name or p.name).replace("-", "_")
+
+
+def _allocate_param_cli_names(cmd: "CommandDef") -> None:
+    """Assign unique parameter flags without shadowing built-in options."""
+    natural_names = {p.name for p in cmd.params}
+    used = {"help"}
+    if cmd.has_body:
+        used.add("stdin")
+
+    for p in cmd.params:
+        name = p.name
+        if name in used:
+            stem = f"arg-{name}"
+            name = stem
+            suffix = 2
+            while name in used or name in natural_names:
+                name = f"{stem}-{suffix}"
+                suffix += 1
+        p.cli_name = name
+        used.add(name)
+
+
 def _param_to_dict(p: "ParamDef") -> dict:
     d = {
-        "name": p.name,
+        "name": p.cli_name or p.name,
         "type": _python_type_name(p.python_type),
         "required": p.required,
         "description": p.description,
@@ -1513,19 +1539,34 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
 
 def extract_mcp_commands(tools: list[dict]) -> list[CommandDef]:
     commands: list[CommandDef] = []
+    base_names = [to_kebab(tool.get("name", "unknown")) for tool in tools]
+    reserved_names = set(base_names)
+    cli_names = [""] * len(tools)
     used_names: set[str] = set()
-    for tool in tools:
-        name = to_kebab(tool.get("name", "unknown"))
-        # Two tools can kebab-case to the same CLI name (get_user + getUser).
-        # argparse raises "conflicting subparser" and bricks the whole CLI, so
-        # de-duplicate here; the original name is still sent on the wire via
-        # tool_name.
-        if name in used_names:
-            suffix = 2
-            while f"{name}-{suffix}" in used_names:
-                suffix += 1
-            name = f"{name}-{suffix}"
-        used_names.add(name)
+    groups: dict[str, list[int]] = {}
+    for index, base_name in enumerate(base_names):
+        groups.setdefault(base_name, []).append(index)
+
+    # Assign aliases from the complete tool-name set so a generated suffix can
+    # never shadow another tool's natural name. Sorting each collision group by
+    # wire name keeps aliases stable when a server reorders tools/list.
+    for base_name in sorted(groups):
+        indices = sorted(
+            groups[base_name],
+            key=lambda index: (tools[index].get("name", "unknown"), index),
+        )
+        for rank, index in enumerate(indices):
+            name = base_name
+            if rank:
+                suffix = 2
+                name = f"{base_name}-{suffix}"
+                while name in reserved_names or name in used_names:
+                    suffix += 1
+                    name = f"{base_name}-{suffix}"
+            cli_names[index] = name
+            used_names.add(name)
+
+    for tool, name in zip(tools, cli_names):
         desc = tool.get("description", "")
         schema = tool.get("inputSchema", {})
         required_fields = set(schema.get("required", []))
@@ -1969,7 +2010,7 @@ def _build_graphql_document(
     else:
         variables = {}
         for p in cmd.params:
-            val = getattr(args, p.name.replace("-", "_"), None)
+            val = getattr(args, _param_dest(p), None)
             if val is not None:
                 variables[p.original_name] = coerce_value(val, p.schema)
 
@@ -2503,6 +2544,7 @@ def build_argparse(
             help=escape_argparse_help(cmd.description),
             description=escape_argparse_help(cmd.description),
         )
+        _allocate_param_cli_names(cmd)
         sub.set_defaults(_cmd=cmd)
 
         if cmd.has_body:
@@ -2513,20 +2555,8 @@ def build_argparse(
                 help="Read JSON body/arguments from stdin",
             )
 
-        seen_flags: set[str] = set()
         for p in cmd.params:
-            flag = f"--{p.name}"
-            # argparse owns --help on every subparser and mcp2cli owns --stdin;
-            # a tool property with one of these names raised "conflicting option
-            # string" while building the parser, which killed *every* command on
-            # that server, not just the offending tool. Rename the flag but pin
-            # dest so argument collection (getattr(args, p.name)) still finds it.
-            renamed = p.name in ("help", "stdin")
-            if renamed:
-                flag = f"--arg-{p.name}"
-            if flag in seen_flags:
-                continue  # skip duplicate param names (e.g. path + body both have same name)
-            seen_flags.add(flag)
+            flag = f"--{p.cli_name or p.name}"
             kwargs: dict = {}
             if p.python_type is not None:
                 kwargs["type"] = p.python_type
@@ -2544,8 +2574,7 @@ def build_argparse(
             kwargs["help"] = escape_argparse_help(p.description)
             if p.choices:
                 kwargs["choices"] = p.choices
-            if renamed:
-                kwargs["dest"] = p.name.replace("-", "_")
+            kwargs["dest"] = _param_dest(p)
             sub.add_argument(flag, **kwargs)
 
     return parser
@@ -2674,13 +2703,13 @@ def _collect_openapi_params(
 
     for p in cmd.params:
         if p.location == "path":
-            val = getattr(args, p.name.replace("-", "_"), None)
+            val = getattr(args, _param_dest(p), None)
             if val is not None:
                 path = path.replace(f"{{{p.original_name}}}", str(val))
 
     if cmd.method == "get":
         for p in cmd.params:
-            val = getattr(args, p.name.replace("-", "_"), None)
+            val = getattr(args, _param_dest(p), None)
             if val is None:
                 continue
             if p.location == "query":
@@ -2693,7 +2722,7 @@ def _collect_openapi_params(
         else:
             body = {}
             for p in cmd.params:
-                val = getattr(args, p.name.replace("-", "_"), None)
+                val = getattr(args, _param_dest(p), None)
                 if p.location == "header":
                     if val is not None:
                         extra_headers[p.original_name] = str(val)
@@ -2718,7 +2747,7 @@ def _collect_openapi_params(
         # Also collect query params for non-GET
         for p in cmd.params:
             if p.location == "query":
-                val = getattr(args, p.name.replace("-", "_"), None)
+                val = getattr(args, _param_dest(p), None)
                 if val is not None:
                     query_params[p.original_name] = coerce_value(val, p.schema)
 
@@ -2803,13 +2832,21 @@ def execute_openapi(
 # ---------------------------------------------------------------------------
 
 
-def _exc_message(exc: BaseException) -> str:
-    """Flatten an exception — incl. anyio ExceptionGroups — into one message."""
+def _exc_leaves(exc: BaseException) -> list[BaseException]:
+    """Flatten nested exception groups into their leaf exceptions."""
     nested = getattr(exc, "exceptions", None)
-    if nested:
-        parts = [_exc_message(e) for e in nested]
-        return "; ".join(p for p in parts if p) or exc.__class__.__name__
-    return str(exc) or exc.__class__.__name__
+    if not nested:
+        return [exc]
+    return [leaf for child in nested for leaf in _exc_leaves(child)]
+
+
+def _exc_message(exc: BaseException) -> str:
+    """Flatten an exception group into one terminal-safe line."""
+    parts = []
+    for leaf in _exc_leaves(exc):
+        message = str(leaf) or leaf.__class__.__name__
+        parts.append("; ".join(line.strip() for line in message.splitlines() if line.strip()))
+    return "; ".join(part for part in parts if part) or exc.__class__.__name__
 
 
 def _run_mcp_clean(fn, source: str):
@@ -2826,6 +2863,9 @@ def _run_mcp_clean(fn, source: str):
     except KeyboardInterrupt:  # pragma: no cover - interactive only
         raise
     except BaseException as exc:
+        leaves = _exc_leaves(exc)
+        if len(leaves) == 1 and isinstance(leaves[0], (SystemExit, KeyboardInterrupt)):
+            raise leaves[0]
         if os.environ.get("MCP2CLI_DEBUG"):
             raise
         message = _exc_message(exc)
@@ -3115,14 +3155,20 @@ async def _mcp_session(
         return 1 if _mcp_attr(result, "isError") else 0
 
     text = _extract_content_parts(result.content)
+    payload = text
+    if not payload:
+        # A tool may return only structuredContent with an empty content list.
+        structured = _mcp_attr(result, "structuredContent")
+        if structured is not None:
+            payload = structured
+
     if _mcp_attr(result, "isError"):
-        # isError is the MCP signal that the tool failed: report on stderr and
-        # exit non-zero so shell pipelines and CI can detect the failure.
-        # Return the code instead of sys.exit() — a SystemExit raised inside
-        # the anyio task group resurfaces as a BaseExceptionGroup traceback.
-        print(f"Error: {text or f'tool {tool_name!r} reported an error'}", file=sys.stderr)
+        # Return the code instead of raising inside the anyio task group, which
+        # would wrap SystemExit in a BaseExceptionGroup traceback.
+        error = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+        print(f"Error: {error or f'tool {tool_name!r} reported an error'}", file=sys.stderr)
         return 1
-    output_result(text, pretty=pretty, raw=raw, toon=toon, head=head)
+    output_result(payload, pretty=pretty, raw=raw, toon=toon, head=head)
     return 0
 
 
@@ -3379,15 +3425,17 @@ def _extract_content_parts(content_list, *, attrs=("text", "data")) -> str:
     ``name: uri`` (or just the URI) instead.
     """
     parts = []
-    for c in content_list:
+    for content in content_list:
+        is_mapping = isinstance(content, dict)
         for attr in attrs:
-            if hasattr(c, attr):
-                parts.append(getattr(c, attr))
+            value = content.get(attr) if is_mapping else getattr(content, attr, None)
+            if value is not None:
+                parts.append(value)
                 break
         else:
-            uri = getattr(c, "uri", None)
+            uri = content.get("uri") if is_mapping else getattr(content, "uri", None)
             if uri is not None:
-                name = getattr(c, "name", None)
+                name = content.get("name") if is_mapping else getattr(content, "name", None)
                 parts.append(f"{name}: {uri}" if name else str(uri))
     return "\n".join(parts) if parts else ""
 
@@ -3422,10 +3470,7 @@ async def _dispatch_list_tools(session, params):
 
 async def _dispatch_call_tool(session, params):
     result = await session.call_tool(params["name"], params.get("arguments", {}))
-    return {
-        "content": _extract_content_parts(result.content),
-        "isError": bool(_mcp_attr(result, "isError")),
-    }
+    return _mcp_dump(result)
 
 
 async def _dispatch_list_resources(session, params):
@@ -3882,7 +3927,7 @@ def handle_mcp(
     else:
         arguments = {}
         for p in cmd.params:
-            val = getattr(args, p.name.replace("-", "_"), None)
+            val = getattr(args, _param_dest(p), None)
             if val is not None:
                 arguments[p.original_name] = coerce_value(val, p.schema)
 
@@ -4476,7 +4521,7 @@ def _handle_session_operations(
     else:
         arguments = {}
         for p in cmd.params:
-            val = getattr(args, p.name.replace("-", "_"), None)
+            val = getattr(args, _param_dest(p), None)
             if val is not None:
                 arguments[p.original_name] = coerce_value(val, p.schema)
 
@@ -4484,15 +4529,28 @@ def _handle_session_operations(
         sess_name, "call_tool", {"name": cmd.tool_name, "arguments": arguments}
     )
     if isinstance(result, dict) and "isError" in result:
-        # The daemon reports the tool's isError flag; surface it like the
-        # direct path does: stderr + non-zero exit.
+        content = result.get("content") or []
+        text = _extract_content_parts(content) if isinstance(content, list) else content
+        payload = text or result.get("structuredContent") or ""
+
+        if pre_args.json_output:
+            output_result(result, **_sess_out)
+            if result.get("isError"):
+                sys.exit(1)
+            return True
+
         if result.get("isError"):
+            error = (
+                payload
+                if isinstance(payload, str)
+                else json.dumps(payload, ensure_ascii=False)
+            )
             print(
-                f"Error: {result.get('content') or f'tool {cmd.tool_name!r} reported an error'}",
+                f"Error: {error or f'tool {cmd.tool_name!r} reported an error'}",
                 file=sys.stderr,
             )
             sys.exit(1)
-        result = result["content"]
+        result = payload
     output_result(result, **_sess_out)
     return True
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -178,8 +178,17 @@ def read_stdin_json(context: str):
         sys.exit(1)
 
 
+def _normalize_schema_type(t):
+    """JSON Schema allows "type": ["integer", "null"] (array form). Reduce it
+    to the single concrete type, dropping "null"; anything else passes through."""
+    if isinstance(t, list):
+        concrete = [x for x in t if x != "null"]
+        return concrete[0] if len(concrete) == 1 else None
+    return t
+
+
 def schema_type_to_python(schema: dict) -> tuple[type | None, str]:
-    t = schema.get("type")
+    t = _normalize_schema_type(schema.get("type"))
     if t == "integer":
         return int, ""
     if t == "number":
@@ -207,7 +216,7 @@ def _coerce_item(value: str, item_type: str | None):
 def coerce_value(value, schema: dict):
     if value is None:
         return None
-    t = schema.get("type")
+    t = _normalize_schema_type(schema.get("type"))
     if t == "array":
         if isinstance(value, list):
             return value
@@ -218,7 +227,7 @@ def coerce_value(value, schema: dict):
                     return parsed
             except (json.JSONDecodeError, TypeError):
                 pass
-            item_type = schema.get("items", {}).get("type")
+            item_type = _normalize_schema_type(schema.get("items", {}).get("type"))
             if "," in value:
                 return [_coerce_item(v.strip(), item_type) for v in value.split(",")]
             return [_coerce_item(value, item_type)]

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1494,8 +1494,19 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
 
 def extract_mcp_commands(tools: list[dict]) -> list[CommandDef]:
     commands: list[CommandDef] = []
+    used_names: set[str] = set()
     for tool in tools:
         name = to_kebab(tool.get("name", "unknown"))
+        # Two tools can kebab-case to the same CLI name (get_user + getUser).
+        # argparse raises "conflicting subparser" and bricks the whole CLI, so
+        # de-duplicate here; the original name is still sent on the wire via
+        # tool_name.
+        if name in used_names:
+            suffix = 2
+            while f"{name}-{suffix}" in used_names:
+                suffix += 1
+            name = f"{name}-{suffix}"
+        used_names.add(name)
         desc = tool.get("description", "")
         schema = tool.get("inputSchema", {})
         required_fields = set(schema.get("required", []))

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -272,13 +272,16 @@ def to_kebab(name: str) -> str:
     return s.replace("_", "-").lower()
 
 
-def _find_toon_cli() -> str | None:
-    """Return the command to invoke the TOON CLI, or None if unavailable."""
+def _find_toon_cli() -> tuple[str, ...] | None:
+    """Return argv for the TOON CLI, or None if unavailable."""
     if shutil.which("toon"):
-        return "toon"
-    # Check for npx (ships with Node.js)
+        return ("toon",)
+    # npx ships with Node.js, but having it says nothing about the package.
+    # `--no` forbids npx's implicit registry download, so a missing package
+    # fails in about a second instead of turning --toon into a network fetch
+    # racing the timeout in _toon_encode.
     if shutil.which("npx"):
-        return "npx @toon-format/cli"
+        return ("npx", "--no", "@toon-format/cli")
     return None
 
 
@@ -289,7 +292,7 @@ def _toon_encode(json_str: str) -> str | None:
         return None
     try:
         result = subprocess.run(
-            cmd.split(),
+            cmd,
             input=json_str,
             capture_output=True,
             text=True,

--- a/tests/_mcp_fixture.py
+++ b/tests/_mcp_fixture.py
@@ -72,6 +72,11 @@ TOOLS = [
             "required": ["env"],
         },
     },
+    {
+        "name": "fail",
+        "description": "Always fails with isError (for exit-code tests)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
 ]
 
 RESOURCES = [
@@ -151,6 +156,8 @@ def _call_tool(name: str, arguments: dict) -> dict:
             "refresh": arguments.get("refresh", False),
         }
         return {"content": [_text(json.dumps(payload))], "isError": False}
+    if name == "fail":
+        return {"content": [_text("boom: deliberate failure")], "isError": True}
     return {"content": [_text(f"Unknown tool: {name}")], "isError": True}
 
 

--- a/tests/_mcp_fixture.py
+++ b/tests/_mcp_fixture.py
@@ -77,6 +77,23 @@ TOOLS = [
         "description": "Always fails with isError (for exit-code tests)",
         "inputSchema": {"type": "object", "properties": {}},
     },
+    {
+        "name": "struct_only",
+        "description": "Returns only structuredContent (empty content list)",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "reserved_args",
+        "description": "Accepts properties that collide with CLI flags",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "help": {"type": "string"},
+                "stdin": {"type": "boolean"},
+                "arg_stdin": {"type": "string"},
+            },
+        },
+    },
 ]
 
 RESOURCES = [
@@ -158,6 +175,17 @@ def _call_tool(name: str, arguments: dict) -> dict:
         return {"content": [_text(json.dumps(payload))], "isError": False}
     if name == "fail":
         return {"content": [_text("boom: deliberate failure")], "isError": True}
+    if name == "struct_only":
+        return {
+            "content": [],
+            "structuredContent": {"answer": 42},
+            "isError": False,
+        }
+    if name == "reserved_args":
+        return {
+            "content": [_text(json.dumps(arguments, sort_keys=True))],
+            "isError": False,
+        }
     return {"content": [_text(f"Unknown tool: {name}")], "isError": True}
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,6 +59,20 @@ class TestSchemaTypeToPython:
         assert schema_type_to_python({"type": ["integer", "null"]}) == (int, "")
         assert schema_type_to_python({"type": ["number", "null"]}) == (float, "")
         assert schema_type_to_python({"type": ["string", "null"]}) == (str, "")
+    def test_missing_type_int_enum_inferred(self):
+        # No "type" but a numeric enum: argparse must parse the flag as int or
+        # it rejects the value against numeric choices.
+        assert schema_type_to_python({"enum": [1, 2, 3]}) == (int, "")
+
+    def test_missing_type_float_enum_inferred(self):
+        assert schema_type_to_python({"enum": [0.5, 1.5]}) == (float, "")
+
+    def test_missing_type_string_enum_stays_str(self):
+        assert schema_type_to_python({"enum": ["a", "b"]}) == (str, "")
+
+    def test_missing_type_bool_enum_not_inferred(self):
+        # bool is a subclass of int; don't misread a bool enum as int
+        assert schema_type_to_python({"enum": [True, False]}) == (str, "")
 
 
 class TestCoerceValue:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -426,6 +426,20 @@ class TestExtractMCPCommands:
         assert cmds[0].name == "list-items"
         assert cmds[0].tool_name == "list_items"
 
+    def test_kebab_collision_deduplicated(self):
+        """get_user + getUser both kebab to get-user; argparse would raise
+        'conflicting subparser' and brick the CLI. Names must be unique while
+        tool_name keeps the original wire name."""
+        tools = [
+            {"name": "get_user", "description": "snake", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "getUser", "description": "camel", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "get-user", "description": "kebab", "inputSchema": {"type": "object", "properties": {}}},
+        ]
+        cmds = extract_mcp_commands(tools)
+        names = [c.name for c in cmds]
+        assert len(set(names)) == 3
+        assert [c.tool_name for c in cmds] == ["get_user", "getUser", "get-user"]
+
 
 class TestSplitAtSubcommand:
     """Tests for _split_at_subcommand() — GH #15."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -54,6 +54,12 @@ class TestSchemaTypeToPython:
     def test_missing_type(self):
         assert schema_type_to_python({}) == (str, "")
 
+    def test_union_type_array_form(self):
+        # JSON Schema allows "type": ["integer", "null"]
+        assert schema_type_to_python({"type": ["integer", "null"]}) == (int, "")
+        assert schema_type_to_python({"type": ["number", "null"]}) == (float, "")
+        assert schema_type_to_python({"type": ["string", "null"]}) == (str, "")
+
 
 class TestCoerceValue:
     def test_none(self):
@@ -64,6 +70,11 @@ class TestCoerceValue:
 
     def test_number(self):
         assert coerce_value("3.14", {"type": "number"}) == 3.14
+
+    def test_union_type_array_form(self):
+        # "type": ["integer", "null"] must still coerce to int
+        assert coerce_value("42", {"type": ["integer", "null"]}) == 42
+        assert coerce_value("3.14", {"type": ["number", "null"]}) == 3.14
 
     def test_boolean(self):
         assert coerce_value(True, {"type": "boolean"}) is True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,6 +10,7 @@ from mcp2cli import (
     CommandDef,
     _apply_head,
     _collect_openapi_params,
+    _extract_content_parts,
     _find_toon_cli,
     _list_all_tools,
     _split_at_subcommand,
@@ -667,3 +668,19 @@ class TestListAllTools:
         session = _FakeSession([(None, _FakePage([], next_cursor=None))])
         tools = asyncio.run(_list_all_tools(session))
         assert tools == []
+
+
+class TestExtractContentParts:
+    def test_resource_link_block_is_rendered(self):
+        """resource_link blocks carry only uri/name and must not be dropped."""
+        from types import SimpleNamespace
+
+        text_block = SimpleNamespace(text="see:")
+        link = SimpleNamespace(uri="probe://linked", name="linked-doc")
+        assert _extract_content_parts([text_block, link]) == "see:\nlinked-doc: probe://linked"
+
+    def test_resource_link_without_name(self):
+        from types import SimpleNamespace
+
+        link = SimpleNamespace(uri="probe://linked")
+        assert _extract_content_parts([link]) == "probe://linked"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,6 +59,7 @@ class TestSchemaTypeToPython:
         assert schema_type_to_python({"type": ["integer", "null"]}) == (int, "")
         assert schema_type_to_python({"type": ["number", "null"]}) == (float, "")
         assert schema_type_to_python({"type": ["string", "null"]}) == (str, "")
+
     def test_missing_type_int_enum_inferred(self):
         # No "type" but a numeric enum: argparse must parse the flag as int or
         # it rejects the value against numeric choices.
@@ -89,6 +90,13 @@ class TestCoerceValue:
         # "type": ["integer", "null"] must still coerce to int
         assert coerce_value("42", {"type": ["integer", "null"]}) == 42
         assert coerce_value("3.14", {"type": ["number", "null"]}) == 3.14
+
+    def test_array_items_union_type(self):
+        schema = {
+            "type": "array",
+            "items": {"type": ["integer", "null"]},
+        }
+        assert coerce_value("1,2", schema) == [1, 2]
 
     def test_boolean(self):
         assert coerce_value(True, {"type": "boolean"}) is True
@@ -465,6 +473,19 @@ class TestExtractMCPCommands:
         assert len(set(names)) == 3
         assert [c.tool_name for c in cmds] == ["get_user", "getUser", "get-user"]
 
+    def test_collision_aliases_are_stable_and_preserve_natural_names(self):
+        tools = [
+            {"name": "get_user", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "getUser", "inputSchema": {"type": "object", "properties": {}}},
+            {"name": "get_user_2", "inputSchema": {"type": "object", "properties": {}}},
+        ]
+        first = {cmd.tool_name: cmd.name for cmd in extract_mcp_commands(tools)}
+        reordered = {
+            cmd.tool_name: cmd.name for cmd in extract_mcp_commands(list(reversed(tools)))
+        }
+        assert first == reordered
+        assert first["get_user_2"] == "get-user-2"
+
 
 class TestBuildArgparseReservedFlags:
     """A tool property named help/stdin used to raise 'conflicting option
@@ -486,15 +507,36 @@ class TestBuildArgparseReservedFlags:
     def test_help_property_does_not_brick_parser(self):
         parser = self._build({"help": {"type": "string"}})
         args = parser.parse_args(["weird", "--arg-help", "h1"])
-        assert args.help == "h1"
+        assert args.arg_help == "h1"
 
-    def test_stdin_property_does_not_brick_parser_or_trigger_stdin_mode(self):
+    def test_stdin_property_has_distinct_destination(self):
         parser = self._build({"stdin": {"type": "string"}})
         args = parser.parse_args(["weird", "--arg-stdin", "s1"])
-        assert args.stdin == "s1"  # value, not True -> stdin mode not triggered
-        # built-in --stdin still works
-        args2 = parser.parse_args(["weird", "--stdin"])
-        assert args2.stdin is True
+        assert args.stdin is False
+        assert args.arg_stdin == "s1"
+
+        stdin_args = parser.parse_args(["weird", "--stdin"])
+        assert stdin_args.stdin is True
+        assert stdin_args.arg_stdin is None
+
+    def test_boolean_stdin_property_does_not_trigger_stdin_mode(self):
+        parser = self._build({"stdin": {"type": "boolean"}})
+        args = parser.parse_args(["weird", "--arg-stdin"])
+        assert args.stdin is False
+        assert args.arg_stdin is True
+
+    def test_reserved_alias_does_not_shadow_natural_property(self):
+        parser = self._build(
+            {
+                "help": {"type": "string"},
+                "arg_help": {"type": "string"},
+            }
+        )
+        args = parser.parse_args(
+            ["weird", "--arg-help-2", "reserved", "--arg-help", "natural"]
+        )
+        assert args.arg_help_2 == "reserved"
+        assert args.arg_help == "natural"
 
 
 class TestSplitAtSubcommand:
@@ -754,3 +796,10 @@ class TestExtractContentParts:
 
         link = SimpleNamespace(uri="probe://linked")
         assert _extract_content_parts([link]) == "probe://linked"
+
+    def test_serialized_content_blocks_are_rendered(self):
+        blocks = [
+            {"type": "text", "text": "see:"},
+            {"type": "resource_link", "uri": "probe://linked", "name": "linked-doc"},
+        ]
+        assert _extract_content_parts(blocks) == "see:\nlinked-doc: probe://linked"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -441,6 +441,37 @@ class TestExtractMCPCommands:
         assert [c.tool_name for c in cmds] == ["get_user", "getUser", "get-user"]
 
 
+class TestBuildArgparseReservedFlags:
+    """A tool property named help/stdin used to raise 'conflicting option
+    string' during parser build, killing every command on that server."""
+
+    def _build(self, props):
+        from mcp2cli import build_argparse
+
+        tools = [
+            {
+                "name": "weird",
+                "description": "reserved props",
+                "inputSchema": {"type": "object", "properties": props},
+            }
+        ]
+        pre = argparse.ArgumentParser(add_help=False)
+        return build_argparse(extract_mcp_commands(tools), pre)
+
+    def test_help_property_does_not_brick_parser(self):
+        parser = self._build({"help": {"type": "string"}})
+        args = parser.parse_args(["weird", "--arg-help", "h1"])
+        assert args.help == "h1"
+
+    def test_stdin_property_does_not_brick_parser_or_trigger_stdin_mode(self):
+        parser = self._build({"stdin": {"type": "string"}})
+        args = parser.parse_args(["weird", "--arg-stdin", "s1"])
+        assert args.stdin == "s1"  # value, not True -> stdin mode not triggered
+        # built-in --stdin still works
+        args2 = parser.parse_args(["weird", "--stdin"])
+        assert args2.stdin is True
+
+
 class TestSplitAtSubcommand:
     """Tests for _split_at_subcommand() — GH #15."""
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -253,20 +253,27 @@ class TestApplyHead:
 
 
 class TestToonEncode:
+    def test_find_toon_cli_prefers_installed_binary(self, monkeypatch):
+        """A real `toon` on PATH is used directly, without involving npx."""
+        monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+        assert _find_toon_cli() == ("toon",)
+
     def test_find_toon_cli_npx(self, monkeypatch):
-        """Falls back to npx when toon binary isn't in PATH."""
-        original_which = shutil.which
-        def mock_which(cmd):
-            if cmd == "toon":
-                return None
-            return original_which(cmd)
-        monkeypatch.setattr(shutil, "which", mock_which)
-        result = _find_toon_cli()
-        # Either npx is available or None
-        if shutil.which("npx") is not None:
-            assert result == "npx @toon-format/cli"
-        else:
-            assert result is None
+        """Falls back to npx when the toon binary isn't in PATH.
+
+        The npx form must pass --no: without it npx silently downloads the
+        package from the registry mid-command, so --toon becomes a multi-second
+        network fetch racing _toon_encode's timeout.
+        """
+        monkeypatch.setattr(
+            shutil, "which", lambda cmd: None if cmd == "toon" else f"/usr/bin/{cmd}"
+        )
+        assert _find_toon_cli() == ("npx", "--no", "@toon-format/cli")
+
+    def test_find_toon_cli_absent(self, monkeypatch):
+        """No toon binary and no npx means no TOON support."""
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        assert _find_toon_cli() is None
 
     def test_toon_encode_uniform_array(self):
         """TOON CLI encodes a uniform array into tabular format."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -168,6 +168,23 @@ class TestMCPStdio:
         r2 = self._run("echo", "--message", "second")
         assert r2.returncode == 0
 
+    # --- Tool failures (isError) ---
+
+    def test_iserror_tool_exits_nonzero(self):
+        """A tool result with isError=true must exit non-zero, on stderr."""
+        r = self._run("fail")
+        assert r.returncode != 0
+        assert "boom: deliberate failure" in r.stderr
+        assert "boom: deliberate failure" not in r.stdout
+
+    def test_iserror_tool_json_keeps_envelope_but_exits_nonzero(self):
+        """--json still emits the full envelope, but the exit code reflects failure."""
+        r = self._run("--json", "fail")
+        assert r.returncode != 0
+        envelope = json.loads(r.stdout)
+        assert envelope["isError"] is True
+        assert envelope["content"][0]["text"] == "boom: deliberate failure"
+
     # --- Resources ---
 
     def test_list_resources(self):
@@ -405,4 +422,62 @@ class TestSessions:
             timeout=10,
         )
         assert name not in r.stdout or "dead" in r.stdout
+
+    def test_session_iserror_tool_exits_nonzero(self):
+        """isError through the session daemon must also exit non-zero."""
+        server = f"{sys.executable} {MCP_SERVER}"
+        name = "test-iserror"
+
+        r = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mcp2cli",
+                "--mcp-stdio",
+                server,
+                "--session-start",
+                name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert r.returncode == 0
+
+        try:
+            r = subprocess.run(
+                [sys.executable, "-m", "mcp2cli", "--session", name, "fail"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode != 0
+            assert "boom: deliberate failure" in r.stderr
+            assert "boom: deliberate failure" not in r.stdout
+
+            # Successful calls still print to stdout and exit 0.
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--session",
+                    name,
+                    "echo",
+                    "--message",
+                    "still fine",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode == 0
+            assert "still fine" in r.stdout
+        finally:
+            subprocess.run(
+                [sys.executable, "-m", "mcp2cli", "--session-stop", name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -65,6 +65,33 @@ class TestMCPStdio:
         data = json.loads(r.stdout)
         assert data["recursive"] is True
 
+    def test_structured_content_only(self):
+        """A tool returning only structuredContent (empty content list) must
+        still print the payload instead of printing nothing."""
+        # --refresh: the tool list is cached on disk by server command; force a
+        # re-fetch so this test doesn't depend on cache freshness.
+        r = self._run("--refresh", "struct-only")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data == {"answer": 42}
+
+    def test_reserved_boolean_stdin_property_reaches_tool(self):
+        r = self._run(
+            "--refresh",
+            "reserved-args",
+            "--arg-help",
+            "details",
+            "--arg-stdin-2",
+            "--arg-stdin",
+            "literal",
+        )
+        assert r.returncode == 0
+        assert json.loads(r.stdout) == {
+            "arg_stdin": "literal",
+            "help": "details",
+            "stdin": True,
+        }
+
     def test_echo_stdin(self):
         r = self._run("echo", "--stdin", stdin_data='{"message": "from stdin"}')
         assert r.returncode == 0
@@ -270,6 +297,16 @@ class TestMCPHTTP:
         assert r.returncode == 0
         assert "30" in r.stdout
 
+    def test_iserror_http_exits_nonzero(self, mcp_http_server):
+        plain = self._run(mcp_http_server, "fail")
+        assert plain.returncode != 0
+        assert "boom: deliberate failure" in plain.stderr
+        assert plain.stdout == ""
+
+        machine = self._run(mcp_http_server, "--json", "fail")
+        assert machine.returncode != 0
+        assert json.loads(machine.stdout)["isError"] is True
+
     # --- Resources (HTTP) ---
 
     def test_list_resources_http(self, mcp_http_server):
@@ -456,6 +493,39 @@ class TestSessions:
             assert "boom: deliberate failure" in r.stderr
             assert "boom: deliberate failure" not in r.stdout
 
+            machine = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--json",
+                    "--session",
+                    name,
+                    "fail",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert machine.returncode != 0
+            assert json.loads(machine.stdout)["isError"] is True
+
+            structured = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--session",
+                    name,
+                    "struct-only",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert structured.returncode == 0
+            assert json.loads(structured.stdout) == {"answer": 42}
+
             # Successful calls still print to stdout and exit 0.
             r = subprocess.run(
                 [
@@ -481,15 +551,20 @@ class TestSessions:
                 text=True,
                 timeout=10,
             )
+
 class TestConnectionErrors:
     """Transport failures must report one clean error line, not a traceback."""
 
     def _run(self, *args):
+        import os
+
+        env = {key: value for key, value in os.environ.items() if key != "MCP2CLI_DEBUG"}
         return subprocess.run(
             [sys.executable, "-m", "mcp2cli", *args],
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
 
 
@@ -528,8 +603,22 @@ class TestConnectionErrors:
             assert r.returncode != 0
             assert "Traceback" not in r.stderr
             assert "--auth-header" in r.stderr
+            assert len(r.stderr.splitlines()) == 1
         finally:
             server.shutdown()
+
+    def test_grouped_system_exit_preserves_code(self):
+        import anyio
+
+        from mcp2cli import _run_mcp_clean
+
+        async def exit_inside_task_group():
+            async with anyio.create_task_group():
+                raise SystemExit(3)
+
+        with pytest.raises(SystemExit) as caught:
+            _run_mcp_clean(exit_inside_task_group, "test")
+        assert caught.value.code == 3
 
     def test_debug_env_restores_traceback(self):
         import os

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -442,6 +442,7 @@ class TestSessions:
             text=True,
             timeout=30,
         )
+
         assert r.returncode == 0
 
         try:
@@ -480,4 +481,70 @@ class TestSessions:
                 text=True,
                 timeout=10,
             )
+class TestConnectionErrors:
+    """Transport failures must report one clean error line, not a traceback."""
 
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, "-m", "mcp2cli", *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+
+    def test_unreachable_server_is_one_clean_line(self):
+        r = self._run(
+            "--mcp", "http://127.0.0.1:9/mcp", "--list", "--transport", "streamable"
+        )
+        assert r.returncode != 0
+        assert "Traceback" not in r.stderr
+        assert "Error: cannot use MCP server at http://127.0.0.1:9/mcp" in r.stderr
+        assert r.stdout == ""
+
+    def test_auth_rejection_hints_at_credentials(self):
+        """A 401/403 should suggest --auth-header instead of dumping a traceback."""
+        import http.server
+        import threading
+
+        class Deny(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(401)
+                self.end_headers()
+
+            def do_POST(self):
+                self.send_response(401)
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Deny)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            r = self._run("--mcp", f"http://127.0.0.1:{port}/mcp", "--list")
+            assert r.returncode != 0
+            assert "Traceback" not in r.stderr
+            assert "--auth-header" in r.stderr
+        finally:
+            server.shutdown()
+
+    def test_debug_env_restores_traceback(self):
+        import os
+
+        env = {**os.environ, "MCP2CLI_DEBUG": "1"}
+        r = subprocess.run(
+            [
+                sys.executable, "-m", "mcp2cli",
+                "--mcp", "http://127.0.0.1:9/mcp", "--list",
+                "--transport", "streamable",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert r.returncode != 0
+        assert "Traceback" in r.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem

`main` is red on one job only: `test (py3.13, mcp==1.26.0)`, at `TestToonEncode::test_toon_encode_uniform_array` (`assert None is not None`). The other five matrix jobs pass.

Root cause: `_find_toon_cli()` reported the TOON CLI as available whenever **npx** was on PATH, which says nothing about whether `@toon-format/cli` is installed. Without `--no`, npx *silently downloads the package from the registry* mid-command, and that download runs inside `_toon_encode`'s `timeout=10`. GitHub runners ship npx but not the package, so all six jobs raced the registry; five won, one lost.

Measured locally with an empty npm cache:

| form | exit | time | cache after |
|---|---|---|---|
| `npx --no @toon-format/cli` | 1 | 1.1s | empty (no download) |
| `npx @toon-format/cli` (old) | 0 | 1.5s | **244K downloaded** |

The test's skip guard (`if _find_toon_cli() is None: skip`) cannot detect "npx exists but the package doesn't", so instead of skipping it raced the network.

This is also a user-facing defect, not just CI flake: on any machine with npx but without the package, `--toon` stalled up to 10s doing an implicit npm install of code from the network, then warned and fell back — while the warning text already says `npm install -g @toon-format/cli`.

## Fix

- Pass `--no` to npx so a missing package fails in ~1s rather than installing. `--toon` degrades immediately via the existing JSON fallback + warning.
- Return argv as a tuple, dropping the `cmd.split()` reparse.
- Install `@toon-format/cli` in CI so the encode tests exercise the real encoder deterministically instead of silently skipping — the repo's stated preference (cf. the `mcp_http_server` note on how silent skipping lost streamable-http coverage). `npm install -g` provides a `toon` binary, so `shutil.which("toon")` hits first and npx is bypassed entirely.
- Replace the stale detection test, which hardcoded `"npx @toon-format/cli"` and depended on ambient npx state, with three deterministic cases (binary present / npx-only / neither).

### Second, latent failure this was masking

The red `test` job was hiding a broken `publish` job. `publish` runs on every push to `main`, and `uv publish` is invoked **without `--check-url`**, so it does not skip duplicates — and **3.5.0 is already on PyPI** while `pyproject.toml` still said `3.5.0`. Fixing only the toon flake would have moved the failure from `test` to `publish`. Bumped to **3.6.0**, which is owed regardless: the six fixes merged today (#76, #80, #82, #84, #88, #90) are unreleased.

## Verification

- Full suite: **410 passed** (408 + 2 net new detection tests)
- TOON subset with `toon` on PATH (the CI condition): **7 passed, 0 skipped**, 0.36s
- Real `--toon` output end to end:
  ```
  path: /tmp
  recursive: false
  items[2]: file1.txt,file2.txt
  ```
- Degradation with no CLI installed: warning + JSON fallback, exit 0, no network access
- Confirmed `npm install -g @toon-format/cli` yields `toon` on PATH and `_find_toon_cli() == ('toon',)`