### PR TITLE
feat: MCP roots support + completion/complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ mcp2cli --mcp-stdio "node server.js" --env API_KEY=sk-... --env DEBUG=1 \
   search --query "test"
 ```
 
+### MCP roots and completion
+
+Expose one or more filesystem roots when a server scopes operations to a
+workspace. Paths are converted to `file://` URIs; explicit roots must also use
+the `file://` scheme.
+
+```bash
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --root "$PWD" --root file:///var/shared --list
+```
+
+Request prompt-argument or resource-template completions with
+`REF:ARG=PREFIX`:
+
+```bash
+mcp2cli --mcp https://example.com/mcp \
+  --complete "greeting:name=San"
+mcp2cli --mcp https://example.com/mcp \
+  --complete "file:///docs/{topic}:topic=api"
+```
+
+Both options work when starting a persistent session; roots are retained by
+the session daemon and completion requests can be sent through `--session`.
+
 ### OpenAPI mode
 
 ```bash
@@ -319,6 +343,8 @@ Options:
   --base-url URL          Override base URL from spec
   --transport TYPE        MCP HTTP transport: auto|sse|streamable (default: auto)
   --env KEY=VALUE         Env var for MCP stdio server (repeatable)
+  --root PATH|FILE_URI    Expose a filesystem root to an MCP server (repeatable)
+  --complete SPEC         Complete an MCP prompt or resource-template argument
   --oauth                 Enable OAuth (authorization code + PKCE flow)
   --oauth-client-id ID    OAuth client ID (supports env:/file: prefixes)
   --oauth-client-secret S OAuth client secret (supports env:/file: prefixes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp2cli"
-version = "3.6.0"
+version = "3.7.0"
 description = "Turn any MCP server or OpenAPI spec into a CLI"
 readme = "README.md"
 license = "MIT"

--- a/skills/mcp2cli/SKILL.md
+++ b/skills/mcp2cli/SKILL.md
@@ -60,6 +60,8 @@ Options:
   --base-url URL          Override base URL from spec
   --transport TYPE        MCP HTTP transport: auto|sse|streamable (default: auto)
   --env KEY=VALUE         Env var for stdio server process (repeatable)
+  --root PATH|FILE_URI   Expose a filesystem root to an MCP server (repeatable)
+  --complete SPEC       Complete an MCP prompt or resource-template argument
   --session-start NAME   Start a persistent session daemon (requires --mcp or --mcp-stdio)
   --session NAME         Route command through an existing session daemon
   --session-stop NAME    Stop a named session daemon (sends SIGTERM)
@@ -196,6 +198,32 @@ File parameters show `(file path)` in `--help` output. MIME types are auto-detec
 
 ```bash
 mcp2cli --mcp-stdio "node server.js" --env API_KEY=env:API_SECRET_KEY --env DEBUG=1 search --query "test"
+```
+
+### MCP roots and completion
+
+Workspace-scoped servers can request the filesystem roots exposed by the
+client. Repeat `--root`; local paths become `file://` URIs.
+
+```bash
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --root "$PWD" --root file:///var/shared --list
+```
+
+Ask the server to complete a prompt argument or resource-template variable:
+
+```bash
+mcp2cli --mcp https://example.com/mcp --complete "greeting:name=San"
+mcp2cli --mcp https://example.com/mcp \
+  --complete "file:///docs/{topic}:topic=api"
+```
+
+For persistent connections, pass roots when starting the daemon and route
+completion through the named session:
+
+```bash
+mcp2cli --mcp-stdio "node server.js" --root "$PWD" --session-start workspace
+mcp2cli --session workspace --complete "greeting:name=San"
 ```
 
 ### Session management — persistent MCP connections

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -38,6 +38,8 @@ CACHE_DIR = Path(
     os.environ.get("MCP2CLI_CACHE_DIR", Path.home() / ".cache" / "mcp2cli")
 )
 DEFAULT_CACHE_TTL = 3600
+# Client-side capability the user opted into (see --root).
+_ROOTS: list[str] = []
 USAGE_FILE = CACHE_DIR / "usage.json"
 CONFIG_DIR = Path(
     os.environ.get("MCP2CLI_CONFIG_DIR", Path.home() / ".config" / "mcp2cli")
@@ -2884,6 +2886,29 @@ def _run_mcp_clean(fn, source: str):
         sys.exit(1)
 
 
+def _roots_callback():
+    """Answer ``roots/list`` from --root, or None when none were given.
+
+    Servers that scope themselves to a workspace (filesystem, git, IDE-style
+    servers) ask the client for roots and fall back to something narrower when
+    the client offers none — the filesystem server literally logs "Client does
+    not support MCP Roots".
+    """
+    if not _ROOTS:
+        return None
+
+    from mcp import types
+
+    async def list_roots(context=None):
+        roots = []
+        for raw in _ROOTS:
+            uri = raw if "://" in raw else Path(raw).expanduser().resolve().as_uri()
+            roots.append(types.Root(uri=uri, name=Path(raw).name or uri))
+        return types.ListRootsResult(roots=roots)
+
+    return list_roots
+
+
 def run_mcp_http(
     url: str,
     auth_headers: list[tuple[str, str]],
@@ -2903,6 +2928,7 @@ def run_mcp_http(
     prompt_action: str | None = None,
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
+    complete_spec: str | None = None,
     search_pattern: str | None = None,
     head: int | None = None,
     verbose: bool = False,
@@ -2918,6 +2944,7 @@ def run_mcp_http(
         prompt_action=prompt_action,
         prompt_name=prompt_name,
         prompt_arguments=prompt_arguments,
+        complete_spec=complete_spec,
         search_pattern=search_pattern,
         head=head,
         verbose=verbose,
@@ -2937,7 +2964,7 @@ def run_mcp_http(
             async with _streamable_streams(
                 url, headers=headers, auth=oauth_provider
             ) as (read, write):
-                async with ClientSession(read, write) as session:
+                async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                     await session.initialize()
                     return await _mcp_session(
                         session,
@@ -2960,7 +2987,7 @@ def run_mcp_http(
                 read,
                 write,
             ):
-                async with ClientSession(read, write) as session:
+                async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                     await session.initialize()
                     return await _mcp_session(
                         session,
@@ -3008,6 +3035,7 @@ def run_mcp_stdio(
     prompt_action: str | None = None,
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
+    complete_spec: str | None = None,
     search_pattern: str | None = None,
     head: int | None = None,
     verbose: bool = False,
@@ -3023,6 +3051,7 @@ def run_mcp_stdio(
         prompt_action=prompt_action,
         prompt_name=prompt_name,
         prompt_arguments=prompt_arguments,
+        complete_spec=complete_spec,
         search_pattern=search_pattern,
         head=head,
         verbose=verbose,
@@ -3044,7 +3073,7 @@ def run_mcp_stdio(
         params = StdioServerParameters(command=parts[0], args=parts[1:], env=env)
 
         async with stdio_client(params) as (read, write):
-            async with ClientSession(read, write) as session:
+            async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                 await session.initialize()
                 return await _mcp_session(
                     session,
@@ -3081,6 +3110,7 @@ async def _mcp_session(
     prompt_action: str | None = None,
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
+    complete_spec: str | None = None,
     search_pattern: str | None = None,
     head: int | None = None,
     verbose: bool = False,
@@ -3090,6 +3120,14 @@ async def _mcp_session(
     source_hash: str = "",
     json_output: bool = False,
 ):
+    # Handle completion requests
+    if complete_spec:
+        await _handle_completion(
+            session, complete_spec, pretty, raw, toon, head=head,
+            json_output=json_output,
+        )
+        return
+
     # Handle resource operations
     if resource_action:
         await _handle_resources(
@@ -3230,6 +3268,62 @@ async def _handle_resources(
 # ---------------------------------------------------------------------------
 # Prompts
 # ---------------------------------------------------------------------------
+
+
+def parse_complete_spec(spec: str) -> tuple[str, str, str]:
+    """Parse ``REF:ARG=PREFIX`` into (ref, argument, prefix).
+
+    ``REF`` is a prompt name, or a resource URI template when it contains
+    ``://`` — in which case the scheme's own colons must not be mistaken for
+    the ref/arg separator.
+    """
+    ref_part, sep, prefix = spec.partition("=")
+    if not sep:
+        print(
+            "Error: --complete expects REF:ARG=PREFIX (e.g. 'my-prompt:city=San')",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    ref, sep, argument = ref_part.rpartition(":")
+    if not sep or not ref or not argument:
+        print(
+            f"Error: --complete could not split {ref_part!r} into REF:ARG",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return ref, argument, prefix
+
+
+async def _handle_completion(
+    session,
+    spec: str,
+    pretty: bool,
+    raw: bool,
+    toon: bool,
+    head: int | None = None,
+    json_output: bool = False,
+):
+    """Run ``completion/complete`` for a prompt or resource-template argument."""
+    from mcp import types
+
+    ref_name, argument, prefix = parse_complete_spec(spec)
+    if "://" in ref_name or "{" in ref_name:
+        ref = types.ResourceTemplateReference(
+            type="ref/resource", uri=ref_name
+        )
+    else:
+        ref = types.PromptReference(type="ref/prompt", name=ref_name)
+
+    result = await session.complete(ref, {"name": argument, "value": prefix})
+    completion = getattr(result, "completion", None)
+    data = {
+        "values": list(getattr(completion, "values", []) or []),
+        "total": getattr(completion, "total", None),
+        "hasMore": getattr(completion, "has_more", None),
+    }
+    output_result(
+        data, pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output
+    )
 
 
 async def _handle_prompts(
@@ -3676,7 +3770,7 @@ def _run_session_daemon(config_json: str):
             env = {**os.environ, **env_vars}
             params = StdioServerParameters(command=parts[0], args=parts[1:], env=env)
             async with stdio_client(params) as (read, write):
-                async with ClientSession(read, write) as session:
+                async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                     await _run_with_session(session)
         else:
             headers = dict(auth_headers) if auth_headers else None
@@ -3686,14 +3780,14 @@ def _run_session_daemon(config_json: str):
                     read,
                     write,
                 ):
-                    async with ClientSession(read, write) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                         await _run_with_session(session)
 
             async def _via_sse():
                 from mcp.client.sse import sse_client
 
                 async with sse_client(source, headers=headers) as (read, write):
-                    async with ClientSession(read, write) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                         await _run_with_session(session)
 
             if transport == "sse":
@@ -3821,6 +3915,7 @@ def handle_mcp(
     prompt_action: str | None = None,
     prompt_name: str | None = None,
     prompt_arguments: dict | None = None,
+    complete_spec: str | None = None,
     search_pattern: str | None = None,
     bake_config: BakeConfig | None = None,
     head: int | None = None,
@@ -3842,14 +3937,15 @@ def handle_mcp(
     key = cache_key_override or cache_key_for(config_for_cache)
     src_hash = _source_hash_for(source)
 
-    # Resource/prompt operations skip the tool flow entirely
-    if resource_action or prompt_action:
+    # Resource/prompt/completion operations skip the tool flow entirely
+    if resource_action or prompt_action or complete_spec:
         extra = dict(
             resource_action=resource_action,
             resource_uri=resource_uri,
             prompt_action=prompt_action,
             prompt_name=prompt_name,
             prompt_arguments=prompt_arguments,
+            complete_spec=complete_spec,
             head=head,
             json_output=json_output,
         )
@@ -3977,7 +4073,7 @@ def _fetch_mcp_tools(
             env = {**os.environ, **env_vars}
             params = StdioServerParameters(command=parts[0], args=parts[1:], env=env)
             async with stdio_client(params) as (read, write):
-                async with ClientSession(read, write) as session:
+                async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                     await session.initialize()
                     await _extract_tools(session)
         else:
@@ -3989,7 +4085,7 @@ def _fetch_mcp_tools(
                 async with _streamable_streams(
                     source, headers=headers, auth=oauth_provider
                 ) as (read, write):
-                    async with ClientSession(read, write) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                         await session.initialize()
                         await _extract_tools(session)
 
@@ -4000,7 +4096,7 @@ def _fetch_mcp_tools(
                     read,
                     write,
                 ):
-                    async with ClientSession(read, write) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
                         await session.initialize()
                         await _extract_tools(session)
 
@@ -4198,6 +4294,26 @@ def _build_main_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help="Environment variable KEY=VALUE for MCP stdio (repeatable)",
+    )
+    pre.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        metavar="PATH|URI",
+        help=(
+            "Expose a filesystem root to the server (repeatable). Servers that "
+            "scope themselves to a workspace ask for these via roots/list."
+        ),
+    )
+    pre.add_argument(
+        "--complete",
+        default=None,
+        metavar="REF:ARG=PREFIX",
+        help=(
+            "Ask the server to complete an argument value, e.g. "
+            "--complete 'my-prompt:city=San'. REF is a prompt name, or a "
+            "resource URI template when it contains '://'."
+        ),
     )
     pre.add_argument(
         "--oauth",
@@ -4693,6 +4809,9 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
     pre_args, leftover = pre.parse_known_args(global_argv)
     remaining = leftover + tool_argv
 
+    if pre_args.root:
+        _ROOTS[:] = pre_args.root
+
     # --search implies --list
     search_pattern = pre_args.search_pattern
     if search_pattern:
@@ -4764,6 +4883,7 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
             prompt_action=prompt_action,
             prompt_name=prompt_name,
             prompt_arguments=prompt_arguments,
+            complete_spec=pre_args.complete,
             search_pattern=search_pattern,
             bake_config=bake_config,
             head=pre_args.head,

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -324,6 +324,7 @@ _MCP_RENAMED_FIELDS = {
     "mimeType": "mime_type",
     "structuredContent": "structured_content",
     "isError": "is_error",
+    "hasMore": "has_more",
 }
 
 
@@ -2886,24 +2887,41 @@ def _run_mcp_clean(fn, source: str):
         sys.exit(1)
 
 
-def _roots_callback():
-    """Answer ``roots/list`` from --root, or None when none were given.
+def _normalize_root(raw: str) -> str:
+    """Return a validated file URI for one ``--root`` value."""
+    if "://" in raw:
+        if not raw.casefold().startswith("file://"):
+            raise ValueError(
+                f"--root expects a filesystem path or file:// URI, got {raw!r}"
+            )
+        uri = raw
+    else:
+        uri = Path(raw).expanduser().resolve().as_uri()
 
-    Servers that scope themselves to a workspace (filesystem, git, IDE-style
-    servers) ask the client for roots and fall back to something narrower when
-    the client offers none — the filesystem server literally logs "Client does
-    not support MCP Roots".
-    """
-    if not _ROOTS:
+    from mcp import types
+
+    try:
+        return str(types.Root(uri=uri).uri)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid --root value {raw!r}: {exc}") from exc
+
+
+def _roots_callback(root_uris: list[str] | None = None):
+    """Answer ``roots/list`` from validated file URIs, if any were given."""
+    configured_roots = tuple(_ROOTS if root_uris is None else root_uris)
+    if not configured_roots:
         return None
 
     from mcp import types
 
     async def list_roots(context=None):
-        roots = []
-        for raw in _ROOTS:
-            uri = raw if "://" in raw else Path(raw).expanduser().resolve().as_uri()
-            roots.append(types.Root(uri=uri, name=Path(raw).name or uri))
+        roots = [
+            types.Root(
+                uri=uri,
+                name=Path(urlparse(uri).path).name or uri,
+            )
+            for uri in configured_roots
+        ]
         return types.ListRootsResult(roots=roots)
 
     return list_roots
@@ -3294,16 +3312,8 @@ def parse_complete_spec(spec: str) -> tuple[str, str, str]:
     return ref, argument, prefix
 
 
-async def _handle_completion(
-    session,
-    spec: str,
-    pretty: bool,
-    raw: bool,
-    toon: bool,
-    head: int | None = None,
-    json_output: bool = False,
-):
-    """Run ``completion/complete`` for a prompt or resource-template argument."""
+async def _completion_data(session, spec: str) -> dict:
+    """Run ``completion/complete`` and return its stable wire-shaped payload."""
     from mcp import types
 
     ref_name, argument, prefix = parse_complete_spec(spec)
@@ -3315,12 +3325,25 @@ async def _handle_completion(
         ref = types.PromptReference(type="ref/prompt", name=ref_name)
 
     result = await session.complete(ref, {"name": argument, "value": prefix})
-    completion = getattr(result, "completion", None)
-    data = {
-        "values": list(getattr(completion, "values", []) or []),
-        "total": getattr(completion, "total", None),
-        "hasMore": getattr(completion, "has_more", None),
+    completion = result.completion
+    return {
+        "values": list(completion.values or []),
+        "total": completion.total,
+        "hasMore": _mcp_attr(completion, "hasMore"),
     }
+
+
+async def _handle_completion(
+    session,
+    spec: str,
+    pretty: bool,
+    raw: bool,
+    toon: bool,
+    head: int | None = None,
+    json_output: bool = False,
+):
+    """Run ``completion/complete`` for a prompt or resource-template argument."""
+    data = await _completion_data(session, spec)
     output_result(
         data, pretty=pretty, raw=raw, toon=toon, head=head, json_output=json_output
     )
@@ -3448,6 +3471,7 @@ def session_start(
     auth_headers: list[tuple[str, str]],
     env_vars: dict[str, str],
     transport: str = "auto",
+    roots: list[str] | None = None,
 ):
     """Start a persistent session daemon."""
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
@@ -3478,6 +3502,7 @@ def session_start(
             "auth_headers": auth_headers,
             "env_vars": env_vars,
             "transport": transport,
+            "roots": list(roots or []),
         }
     )
 
@@ -3630,6 +3655,10 @@ async def _dispatch_get_prompt(session, params):
     return {"description": result.description or "", "messages": messages}
 
 
+async def _dispatch_complete(session, params):
+    return await _completion_data(session, params["spec"])
+
+
 _SESSION_DISPATCH = {
     "list_tools": _dispatch_list_tools,
     "call_tool": _dispatch_call_tool,
@@ -3638,6 +3667,7 @@ _SESSION_DISPATCH = {
     "list_resource_templates": _dispatch_list_resource_templates,
     "list_prompts": _dispatch_list_prompts,
     "get_prompt": _dispatch_get_prompt,
+    "complete": _dispatch_complete,
 }
 
 
@@ -3650,6 +3680,7 @@ def _run_session_daemon(config_json: str):
     auth_headers = [tuple(h) for h in config["auth_headers"]]
     env_vars = config["env_vars"]
     transport = config["transport"]
+    roots = config.get("roots", [])
 
     sock_path = _session_sock_path(name)
     meta_path = _session_meta_path(name)
@@ -3770,7 +3801,7 @@ def _run_session_daemon(config_json: str):
             env = {**os.environ, **env_vars}
             params = StdioServerParameters(command=parts[0], args=parts[1:], env=env)
             async with stdio_client(params) as (read, write):
-                async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
+                async with ClientSession(read, write, list_roots_callback=_roots_callback(roots)) as session:
                     await _run_with_session(session)
         else:
             headers = dict(auth_headers) if auth_headers else None
@@ -3780,14 +3811,14 @@ def _run_session_daemon(config_json: str):
                     read,
                     write,
                 ):
-                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback(roots)) as session:
                         await _run_with_session(session)
 
             async def _via_sse():
                 from mcp.client.sse import sse_client
 
                 async with sse_client(source, headers=headers) as (read, write):
-                    async with ClientSession(read, write, list_roots_callback=_roots_callback()) as session:
+                    async with ClientSession(read, write, list_roots_callback=_roots_callback(roots)) as session:
                         await _run_with_session(session)
 
             if transport == "sse":
@@ -4299,10 +4330,10 @@ def _build_main_parser() -> argparse.ArgumentParser:
         "--root",
         action="append",
         default=[],
-        metavar="PATH|URI",
+        metavar="PATH|FILE_URI",
         help=(
-            "Expose a filesystem root to the server (repeatable). Servers that "
-            "scope themselves to a workspace ask for these via roots/list."
+            "Expose a filesystem path or file:// URI to the server (repeatable). "
+            "Workspace-scoped servers request these via roots/list."
         ),
     )
     pre.add_argument(
@@ -4542,6 +4573,7 @@ def _handle_session_operations(
             auth_headers,
             env_vars,
             transport=pre_args.transport,
+            roots=_ROOTS,
         )
         return True
 
@@ -4554,6 +4586,13 @@ def _handle_session_operations(
         pretty=pre_args.pretty, raw=pre_args.raw, toon=pre_args.toon,
         json_output=pre_args.json_output,
     )
+    if pre_args.complete:
+        result = _session_request(
+            sess_name, "complete", {"spec": pre_args.complete}
+        )
+        output_result(result, head=pre_args.head, **_sess_out)
+        return True
+
 
     if pre_args.list_resources:
         result = _session_request(sess_name, "list_resources")
@@ -4809,8 +4848,11 @@ def _main_impl(argv: list[str], bake_config: BakeConfig | None = None):
     pre_args, leftover = pre.parse_known_args(global_argv)
     remaining = leftover + tool_argv
 
-    if pre_args.root:
-        _ROOTS[:] = pre_args.root
+    try:
+        _ROOTS[:] = [_normalize_root(raw) for raw in pre_args.root]
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     # --search implies --list
     search_pattern = pre_args.search_pattern

--- a/tests/_mcp_fixture.py
+++ b/tests/_mcp_fixture.py
@@ -94,6 +94,11 @@ TOOLS = [
             },
         },
     },
+    {
+        "name": "client_roots",
+        "description": "Return roots exposed by the connected client",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
 ]
 
 RESOURCES = [
@@ -240,13 +245,31 @@ def _get_prompt(name: str, arguments: dict) -> dict:
     raise _Error(f"Unknown prompt: {name}")
 
 
+def _complete(params: dict) -> dict:
+    prefix = (params.get("argument") or {}).get("value", "")
+    candidates = ["San Diego", "San Francisco", "San Jose"]
+    matches = [value for value in candidates if value.startswith(prefix)]
+    return {
+        "completion": {
+            "values": matches[:2],
+            "total": len(matches),
+            "hasMore": len(matches) > 2,
+        }
+    }
+
+
 def _result(method: str, params: dict) -> dict:
     if method == "initialize":
         # Echo the client's protocol version back rather than pinning one, so
         # this double stays valid as the SDK advances its LATEST_PROTOCOL_VERSION.
         return {
             "protocolVersion": params.get("protocolVersion", "2025-06-18"),
-            "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
+            "capabilities": {
+                "tools": {},
+                "resources": {},
+                "prompts": {},
+                "completions": {},
+            },
             "serverInfo": {"name": SERVER_NAME, "version": "1.0.0"},
         }
     if method == "ping":
@@ -265,6 +288,8 @@ def _result(method: str, params: dict) -> dict:
         return {"prompts": PROMPTS}
     if method == "prompts/get":
         return _get_prompt(params.get("name", ""), params.get("arguments") or {})
+    if method == "completion/complete":
+        return _complete(params)
     raise _Error(f"Method not found: {method}", METHOD_NOT_FOUND)
 
 

--- a/tests/mcp_test_server.py
+++ b/tests/mcp_test_server.py
@@ -11,7 +11,27 @@ import sys
 from _mcp_fixture import handle
 
 
+def _write(message: dict) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _roots_tool_response(request_id, roots: list[dict]) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps(roots)}],
+            "isError": False,
+        },
+    }
+
+
 def main() -> None:
+    roots_request_id = "test-server-roots"
+    roots: list[dict] | None = []
+    pending_roots_tool_id = None
+
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -20,10 +40,41 @@ def main() -> None:
             message = json.loads(line)
         except json.JSONDecodeError:
             continue
+
+        if message.get("id") == roots_request_id and "result" in message:
+            roots = (message.get("result") or {}).get("roots", [])
+            if pending_roots_tool_id is not None:
+                _write(_roots_tool_response(pending_roots_tool_id, roots))
+                pending_roots_tool_id = None
+            continue
+
+        method = message.get("method")
+        if method == "initialize":
+            capabilities = (message.get("params") or {}).get("capabilities") or {}
+            roots = None if "roots" in capabilities else []
+
+        if method == "notifications/initialized" and roots is None:
+            _write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": roots_request_id,
+                    "method": "roots/list",
+                    "params": {},
+                }
+            )
+            continue
+
+        params = message.get("params") or {}
+        if method == "tools/call" and params.get("name") == "client_roots":
+            if roots is None:
+                pending_roots_tool_id = message["id"]
+            else:
+                _write(_roots_tool_response(message["id"], roots))
+            continue
+
         response = handle(message)
         if response is not None:
-            sys.stdout.write(json.dumps(response) + "\n")
-            sys.stdout.flush()
+            _write(response)
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -262,6 +262,39 @@ class TestMCPStdio:
         # Default name should be "World"
         assert "World" in data["messages"][0]["content"]
 
+    # --- Roots and completion ---
+
+    def test_roots_are_exposed_to_server(self):
+        r = self._run(
+            "--refresh",
+            "--root",
+            "/tmp/workspace",
+            "--root",
+            "file:///var/project",
+            "client-roots",
+        )
+        assert r.returncode == 0
+        roots = json.loads(r.stdout)
+        assert {root["uri"] for root in roots} == {
+            "file:///tmp/workspace",
+            "file:///var/project",
+        }
+        assert {root["name"] for root in roots} == {"workspace", "project"}
+
+    def test_invalid_root_uri_fails_before_connecting(self):
+        r = self._run("--root", "https://example.com/workspace", "--list")
+        assert r.returncode != 0
+        assert "--root expects a filesystem path or file:// URI" in r.stderr
+
+    def test_complete_prompt_argument(self):
+        r = self._run("--complete", "greeting:name=San")
+        assert r.returncode == 0
+        assert json.loads(r.stdout) == {
+            "values": ["San Diego", "San Francisco"],
+            "total": 3,
+            "hasMore": True,
+        }
+
 
 class TestMCPHTTP:
     """Tests for MCP HTTP transport.
@@ -361,6 +394,10 @@ class TestSessions:
                 "mcp2cli",
                 "--mcp-stdio",
                 server,
+                "--root",
+                "/tmp/workspace",
+                "--root",
+                "file:///var/project",
                 "--session-start",
                 name,
             ],
@@ -440,6 +477,49 @@ class TestSessions:
             assert r.returncode == 0
             data = json.loads(r.stdout)
             assert any(d["name"] == "greeting" for d in data)
+
+            # Completion via session
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--session",
+                    name,
+                    "--complete",
+                    "greeting:name=San",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode == 0
+            assert json.loads(r.stdout) == {
+                "values": ["San Diego", "San Francisco"],
+                "total": 3,
+                "hasMore": True,
+            }
+
+            # Roots survive serialization into the session daemon
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mcp2cli",
+                    "--session",
+                    name,
+                    "client-roots",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert r.returncode == 0
+            roots = json.loads(r.stdout)
+            assert {root["uri"] for root in roots} == {
+                "file:///tmp/workspace",
+                "file:///var/project",
+            }
 
         finally:
             # Stop

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "mcp2cli"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fixes #93

## Problem

Two gaps vs the MCP client surface:

1. **Roots** — workspace-scoped servers (filesystem, git, IDE-style) call `roots/list` and fall back to something narrower when the client offers none; the filesystem server literally logs "Client does not support MCP Roots".
2. **Completion** — `completion/complete` (prompt/resource-template argument completion) is unhandled.

## Fix

- `--root PATH/URI` (repeatable) → `_roots_callback()` answers `roots/list`: paths become `file://` URIs, values with `://` pass through untouched. No roots given → `None` callback (SDK default).
- `--complete 'REF:ARG=PREFIX'` → `completion/complete`; REF is a prompt name or a resource-URI template when it contains `://`. Output goes through the standard pretty/raw/toon/json formatters.
- Both wired through all 9 `ClientSession` construction sites (streamable HTTP, SSE, stdio, session daemons).

## Verification

- 124 tests in tests/test_mcp.py + tests/test_oauth.py pass
- The only failures in the full suite (`TestToonEncode`, 2) reproduce on vanilla upstream/main — pre-existing, unrelated
