### PR TITLE
fix(openapi): honour path-item level `parameters`

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1424,6 +1424,29 @@ def load_openapi_spec(
 # ---------------------------------------------------------------------------
 
 
+def _merge_openapi_parameters(path_level, operation_level) -> list[dict]:
+    """Combine path-item parameters with an operation's own.
+
+    OpenAPI 3.x declares that ``parameters`` on a path item apply to every
+    operation under that path. An operation may *override* an inherited
+    parameter by redeclaring the same ``name``/``in`` pair, but it cannot
+    remove one. Operation-level entries therefore win on collision, and the
+    inherited ones are kept otherwise.
+
+    Malformed entries (non-dicts, or missing ``name``) are skipped rather
+    than raising: a spec we did not write should not crash the CLI.
+    """
+    merged: dict[tuple[str, str], dict] = {}
+    for group in (path_level, operation_level):
+        if not isinstance(group, list):
+            continue
+        for param in group:
+            if not isinstance(param, dict) or "name" not in param:
+                continue
+            merged[(param["name"], param.get("in", "query"))] = param
+    return list(merged.values())
+
+
 def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     commands: list[CommandDef] = []
     seen_names: dict[str, int] = {}
@@ -1431,6 +1454,8 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     for path, methods in spec.get("paths", {}).items():
         if not isinstance(methods, dict):
             continue
+        # Applies to every operation under this path (OpenAPI 3.x).
+        shared_params = methods.get("parameters")
         for method, details in methods.items():
             if method not in ("get", "post", "put", "delete", "patch"):
                 continue
@@ -1458,8 +1483,11 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
             )
             params: list[ParamDef] = []
 
-            # Parameters (path, query, header)
-            for param in details.get("parameters", []):
+            # Parameters (path, query, header) -- inherited from the
+            # path item, then overridden by the operation's own.
+            for param in _merge_openapi_parameters(
+                shared_params, details.get("parameters")
+            ):
                 schema = param.get("schema", {})
                 py_type, suffix = schema_type_to_python(schema)
                 p = ParamDef(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,106 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _path_level_param_spec():
+    """A path item that declares its parameters once, for every operation."""
+    return {
+        "openapi": "3.0.0",
+        "paths": {
+            "/users/{userId}": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "name": "verbose",
+                        "in": "query",
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "get": {"operationId": "getUser", "responses": {}},
+                "delete": {"operationId": "deleteUser", "responses": {}},
+            }
+        },
+    }
+
+
+class TestPathLevelParameters:
+    """OpenAPI 3.x: `parameters` on a path item apply to every operation."""
+
+    def test_inherited_by_every_operation(self):
+        cmds = extract_openapi_commands(_path_level_param_spec())
+        by_name = {c.name: c for c in cmds}
+        assert set(by_name) == {"get-user", "delete-user"}
+        for cmd in by_name.values():
+            locations = {p.original_name: p.location for p in cmd.params}
+            assert locations == {"userId": "path", "verbose": "query"}
+
+    def test_path_placeholder_is_substituted(self):
+        cmd = extract_openapi_commands(_path_level_param_spec())[0]
+        args = argparse.Namespace(user_id="u-42", verbose=None, stdin=False)
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert path == "/users/u-42"
+
+    def test_operation_level_overrides_inherited(self):
+        spec = _path_level_param_spec()
+        spec["paths"]["/users/{userId}"]["get"]["parameters"] = [
+            {
+                "name": "userId",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "integer"},
+            }
+        ]
+        cmds = {c.name: c for c in extract_openapi_commands(spec)}
+        get_param = next(
+            p for p in cmds["get-user"].params if p.original_name == "userId"
+        )
+        # The operation's narrower declaration wins...
+        assert get_param.python_type is int
+        # ...while the sibling operation keeps the inherited one.
+        del_param = next(
+            p for p in cmds["delete-user"].params if p.original_name == "userId"
+        )
+        assert del_param.python_type is str
+        # An override must not drop the other inherited parameters.
+        assert {p.original_name for p in cmds["get-user"].params} == {
+            "userId",
+            "verbose",
+        }
+
+    def test_operation_level_only_still_works(self):
+        spec = {
+            "openapi": "3.0.0",
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "parameters": [
+                            {"name": "limit", "in": "query",
+                             "schema": {"type": "integer"}}
+                        ],
+                        "responses": {},
+                    }
+                }
+            },
+        }
+        cmd = extract_openapi_commands(spec)[0]
+        assert [p.original_name for p in cmd.params] == ["limit"]
+
+    def test_malformed_parameter_entries_are_skipped(self):
+        spec = {
+            "openapi": "3.0.0",
+            "paths": {
+                "/x": {
+                    "parameters": ["not-a-dict", {"no_name": True}],
+                    "get": {"operationId": "getX", "responses": {}},
+                }
+            },
+        }
+        cmd = extract_openapi_commands(spec)[0]
+        assert cmd.params == []


### PR DESCRIPTION
Fixes #95

## Problem

`extract_openapi_commands` reads only the operation-level `parameters` list. OpenAPI 3.x also lets a **path item** declare parameters once for every operation beneath it, and those were dropped entirely.

For a path parameter this fails silently rather than loudly: no flag is generated, nothing substitutes the placeholder, and the request is sent to the literal templated URL — `GET /users/{userId}`.

## Change

Merge the path-item list with the operation list, keyed on `(name, in)`:

- inherited parameters are kept,
- an operation redeclaring the same `name`/`in` overrides the inherited one,
- an operation cannot remove an inherited parameter.

That is exactly what the spec prescribes:

> A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there.

Malformed entries (non-dicts, or missing `name`) are skipped rather than raising. The previous code indexed `param["name"]` unguarded, so a junk entry in a third-party spec could take down the whole CLI; this closes that too.

## Tests

Five tests in `tests/test_openapi.py::TestPathLevelParameters` covering:

- inheritance by every operation under the path
- placeholder substitution actually reaching `/users/u-42`
- operation-level override winning, without dropping the operation's other inherited parameters, and without affecting a sibling operation
- operation-only specs still behaving as before (no regression)
- malformed entries being skipped

Verified they fail on `main` and pass with the change:

```
--- WITHOUT FIX ---
FAILED tests/test_openapi.py::TestPathLevelParameters::test_inherited_by_every_operation
FAILED tests/test_openapi.py::TestPathLevelParameters::test_path_placeholder_is_substituted
FAILED tests/test_openapi.py::TestPathLevelParameters::test_operation_level_overrides_inherited
3 failed, 2 passed

--- WITH FIX ---
5 passed
```

Full suite: `39 passed` in `tests/test_openapi.py`; no other suite touched.

## Note

I have two further OpenAPI fixes coming that also touch `extract_openapi_commands` (name-collision handling) and `_collect_openapi_params` (query params leaking into the JSON body). They are separate issues and separate PRs; the name-collision one edits lines adjacent to this hunk, so whichever merges second may need a trivial rebase.
