### PR TITLE
fix(openapi): dedupe colliding command names so a spec cannot brick the CLI

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1424,32 +1424,75 @@ def load_openapi_spec(
 # ---------------------------------------------------------------------------
 
 
+_OPENAPI_METHODS = ("get", "post", "put", "delete", "patch")
+
+
+def _openapi_operation_name(path: str, method: str, details: dict) -> str:
+    """The natural CLI name for an operation, before collision handling."""
+    op_id = details.get("operationId")
+    if op_id:
+        return to_kebab(op_id)
+    slug = path.strip("/").replace("/", "-").replace("{", "").replace("}", "")
+    return f"{method}-{slug}" if slug else method
+
+
+def _openapi_natural_names(spec: dict) -> set[str]:
+    """Every operation's natural name, so an alias can never shadow one."""
+    names: set[str] = set()
+    for path, methods in spec.get("paths", {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, details in methods.items():
+            if method not in _OPENAPI_METHODS or not isinstance(details, dict):
+                continue
+            names.add(_openapi_operation_name(path, method, details))
+    return names
+
+
+def _unique_openapi_name(
+    name: str, method: str, reserved: set[str], used: set[str]
+) -> str:
+    """Return a free CLI name for an operation.
+
+    The first operation to claim a name keeps it. A later collision is
+    disambiguated by the HTTP method, and then by a numeric suffix if that is
+    taken too. A generated alias is never allowed to equal another
+    operation's natural name, which would make that operation unreachable.
+    """
+    if name not in used:
+        return name
+    candidate = f"{name}-{method}"
+    if candidate not in reserved and candidate not in used:
+        return candidate
+    suffix = 2
+    while True:
+        numbered = f"{candidate}-{suffix}"
+        if numbered not in reserved and numbered not in used:
+            return numbered
+        suffix += 1
+
+
 def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     commands: list[CommandDef] = []
-    seen_names: dict[str, int] = {}
+    natural_names = _openapi_natural_names(spec)
+    used_names: set[str] = set()
 
     for path, methods in spec.get("paths", {}).items():
         if not isinstance(methods, dict):
             continue
         for method, details in methods.items():
-            if method not in ("get", "post", "put", "delete", "patch"):
+            if method not in _OPENAPI_METHODS:
                 continue
             if not isinstance(details, dict):
                 continue
 
-            op_id = details.get("operationId")
-            if op_id:
-                name = to_kebab(op_id)
-            else:
-                slug = (
-                    path.strip("/").replace("/", "-").replace("{", "").replace("}", "")
-                )
-                name = f"{method}-{slug}" if slug else method
-
-            if name in seen_names:
-                seen_names[name] += 1
-                name = f"{name}-{method}"
-            seen_names[name] = 1
+            name = _unique_openapi_name(
+                _openapi_operation_name(path, method, details),
+                method,
+                natural_names,
+                used_names,
+            )
+            used_names.add(name)
 
             desc = (
                 details.get("summary")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,81 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _collision_spec(*entries):
+    """Build a spec from (path, method, operationId) triples."""
+    paths: dict = {}
+    for path, method, op_id in entries:
+        op: dict = {"responses": {}}
+        if op_id is not None:
+            op["operationId"] = op_id
+        paths.setdefault(path, {})[method] = op
+    return {"openapi": "3.0.0", "paths": paths}
+
+
+class TestCommandNameCollisions:
+    """Colliding OpenAPI command names must stay unique and addressable."""
+
+    def test_three_way_collision_stays_unique(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThing"),
+        )
+        names = [c.name for c in extract_openapi_commands(spec)]
+        assert len(names) == len(set(names))
+        assert names == ["do-thing", "do-thing-post", "do-thing-post-2"]
+
+    def test_three_way_collision_builds_a_parser(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThing"),
+        )
+        cmds = extract_openapi_commands(spec)
+        parser = build_argparse(cmds, argparse.ArgumentParser(add_help=False))
+        for cmd in cmds:
+            args = parser.parse_args([cmd.name])
+            assert args._cmd is cmd
+
+    def test_method_suffix_used_when_free(self):
+        spec = _collision_spec(
+            ("/a", "get", "doThing"),
+            ("/b", "post", "doThing"),
+        )
+        assert [c.name for c in extract_openapi_commands(spec)] == [
+            "do-thing",
+            "do-thing-post",
+        ]
+
+    def test_alias_never_shadows_another_natural_name(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThingPost"),
+        )
+        cmds = extract_openapi_commands(spec)
+        names = [c.name for c in cmds]
+        assert len(names) == len(set(names))
+        by_op = {c.path: c.name for c in cmds}
+        assert by_op["/c"] == "do-thing-post"
+        assert by_op["/b"] == "do-thing-post-2"
+
+    def test_pathless_slug_names_still_unique(self):
+        spec = _collision_spec(
+            ("/items", "get", None),
+            ("/items", "post", None),
+        )
+        names = [c.name for c in extract_openapi_commands(spec)]
+        assert names == ["get-items", "post-items"]
+
+    def test_no_collision_leaves_names_untouched(self):
+        spec = _collision_spec(
+            ("/a", "get", "listThings"),
+            ("/b", "post", "createThing"),
+        )
+        assert [c.name for c in extract_openapi_commands(spec)] == [
+            "list-things",
+            "create-thing",
+        ]


### PR DESCRIPTION
Fixes #97

## Problem

Colliding OpenAPI command names were disambiguated by appending the HTTP method, with no check that the result was free:

```python
if name in seen_names:
    seen_names[name] += 1
    name = f"{name}-{method}"
seen_names[name] = 1
```

Three operations sharing an `operationId` on the same verb produced `['do-thing', 'do-thing-post', 'do-thing-post']`, and argparse rejects the duplicate:

```
ArgumentError: argument _command: conflicting subparser: do-thing-post
```

That kills every command, not just the colliding one — `--list` and all unrelated operations included. The `seen_names[name] = 1` reassignment also meant the counter never accumulated.

A second, quieter failure: the method suffix could steal a name belonging to a real operation, making that operation unreachable.

## Change

Allocate names against the set of every operation's natural name, the way `extract_mcp_commands` already does for tool names since #80:

- first claim wins,
- a collision falls back to `<name>-<method>`,
- then to `<name>-<method>-<n>`,
- and a generated alias is never allowed to equal another operation's natural name.

Three small helpers (`_openapi_operation_name`, `_openapi_natural_names`, `_unique_openapi_name`) plus a shared `_OPENAPI_METHODS` tuple, which the main loop now reuses instead of repeating the literal.

## Tests

Six tests in `tests/test_openapi.py::TestCommandNameCollisions`:

- three-way collision stays unique, and the resulting parser actually round-trips every command
- the method suffix is used when free
- an alias never shadows another operation's natural name
- slug-derived names (no `operationId`) stay unique
- non-colliding specs are completely unaffected

Verified against `main`:

```
--- WITHOUT FIX ---
FAILED TestCommandNameCollisions::test_three_way_collision_stays_unique
FAILED TestCommandNameCollisions::test_three_way_collision_builds_a_parser
FAILED TestCommandNameCollisions::test_alias_never_shadows_another_natural_name
3 failed, 3 passed

--- WITH FIX ---
40 passed
```

## Note

Branched from `main`, as is #96 (path-item `parameters`). Both touch `extract_openapi_commands`, in adjacent but distinct hunks — whichever lands second may want a trivial rebase.
