### PR TITLE
fix(openapi): stop query parameters leaking into the JSON request body

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2733,7 +2733,11 @@ def _collect_openapi_params(
                     if val is not None:
                         extra_headers[p.original_name] = str(val)
                     continue
-                if p.location == "path":
+                if p.location in ("path", "query", "cookie"):
+                    # Path and query values travel in the URL, and a cookie
+                    # parameter is not a body field either. None of them
+                    # belong in the JSON payload. Query values are collected
+                    # separately below.
                     continue
                 if p.location == "file":
                     if val is not None:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,107 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _mixed_location_spec(method="post"):
+    """An operation carrying query, header, path and body parameters at once."""
+    return {
+        "openapi": "3.0.0",
+        "paths": {
+            "/tenants/{tenantId}/items": {
+                method: {
+                    "operationId": "createItem",
+                    "parameters": [
+                        {"name": "tenantId", "in": "path", "required": True,
+                         "schema": {"type": "string"}},
+                        {"name": "dryRun", "in": "query",
+                         "schema": {"type": "string"}},
+                        {"name": "region", "in": "query",
+                         "schema": {"type": "string"}},
+                        {"name": "X-Trace", "in": "header",
+                         "schema": {"type": "string"}},
+                    ],
+                    "requestBody": {"content": {"application/json": {"schema": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                            "name": {"type": "string"},
+                            "qty": {"type": "integer"},
+                        },
+                    }}}},
+                    "responses": {},
+                }
+            }
+        },
+    }
+
+
+class TestQueryParamsStayOutOfBody:
+    """Query parameters belong in the URL, never duplicated into the body."""
+
+    def test_query_param_not_copied_into_json_body(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name="widget", qty=3, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget", "qty": 3}
+        assert query == {"region": "eu"}
+        assert path == "/tenants/acme/items"
+
+    def test_header_and_path_still_excluded_from_body(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run="yes", region=None, x_trace="abc123",
+            name="widget", qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget"}
+        assert headers == {"X-Trace": "abc123"}
+        assert query == {"dryRun": "yes"}
+        assert "tenantId" not in body
+
+    def test_body_becomes_none_when_only_query_supplied(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body is None
+        assert query == {"region": "eu"}
+
+    def test_query_still_collected_with_stdin_body(self, monkeypatch):
+        import io
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        monkeypatch.setattr(sys, "stdin", io.StringIO('{"name": "from-stdin"}'))
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=True,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "from-stdin"}
+        assert query == {"region": "eu"}
+
+    def test_delete_verb_behaves_the_same(self):
+        cmd = extract_openapi_commands(_mixed_location_spec("delete"))[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name="widget", qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget"}
+        assert query == {"region": "eu"}
+
+    def test_get_verb_unaffected(self):
+        spec = _mixed_location_spec("get")
+        cmd = extract_openapi_commands(spec)[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body is None
+        assert query == {"region": "eu"}
+        assert path == "/tenants/acme/items"


### PR DESCRIPTION
Fixes #99

## Problem

On non-GET verbs, `_collect_openapi_params` built the body by walking every parameter and skipping only `header`, `path` and `file`. Query parameters fell through into the body — and were then collected again, correctly, into the query string below.

```
POST /items?tenant=acme
{"tenant": "acme", "name": "widget"}
```

Any body schema with `additionalProperties: false` rejects that with a 400. An API that tolerates unknown fields instead gets a field it never asked for, which can collide with a real body property of the same name. `in: cookie` parameters leaked identically.

GET takes a different branch and was never affected, so this only bit write operations.

## Change

Skip `query` and `cookie` alongside `path` in the body-building loop. The query string itself is untouched — still gathered by the existing pass further down, including when `--stdin` supplies the body.

## Tests

Six tests in `tests/test_openapi.py::TestQueryParamsStayOutOfBody`, using one fixture that carries path, query, header and body parameters simultaneously:

- query parameter stays out of the body and still reaches the query string
- header and path remain excluded; header still reaches the headers dict
- body correctly collapses to `None` when only query values are supplied
- query is still collected when `--stdin` provides the body
- `delete` behaves like `post`
- `get` is unaffected

Verified against `main`:

```
--- WITHOUT FIX ---
FAILED TestQueryParamsStayOutOfBody::test_query_param_not_copied_into_json_body
FAILED TestQueryParamsStayOutOfBody::test_header_and_path_still_excluded_from_body
FAILED TestQueryParamsStayOutOfBody::test_body_becomes_none_when_only_query_supplied
FAILED TestQueryParamsStayOutOfBody::test_delete_verb_behaves_the_same
4 failed, 2 passed

--- WITH FIX ---
40 passed
```

Branched from `main`. Touches `_collect_openapi_params` only, so it is independent of #96 and #98.
