### PR TITLE
fix(cache): survive a corrupt entry and write entries atomically

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -632,18 +632,48 @@ def cache_key_for(config: dict) -> str:
     ).hexdigest()[:16]
 
 def load_cached(key: str, ttl: int) -> dict | None:
+    """Read a cache entry, or None when it is missing, stale or unusable.
+
+    A corrupt entry is treated as a miss rather than an error. The cache is
+    an optimisation, so a bad file should cost one refetch -- not every
+    later invocation, until someone works out which file to delete by hand.
+    This matches _load_usage() and _load_baked_all(), which already tolerate
+    exactly this.
+    """
     path = CACHE_DIR / f"{key}.json"
     if not path.exists():
         return None
-    age = time.time() - path.stat().st_mtime
-    if age >= ttl:
+    try:
+        age = time.time() - path.stat().st_mtime
+        if age >= ttl:
+            return None
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return None
-    return json.loads(path.read_text())
 
 
 def save_cache(key: str, data: dict):
+    """Write a cache entry atomically.
+
+    A plain write_text() is not atomic: an interrupt, a full disk or two
+    concurrent mcp2cli runs can leave a half-written file behind, which is
+    how a cache entry becomes corrupt in the first place. Serialise first,
+    write to a private temp file in the same directory, then os.replace()
+    it into place -- readers only ever observe the old file or the new one.
+    """
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    (CACHE_DIR / f"{key}.json").write_text(json.dumps(data))
+    path = CACHE_DIR / f"{key}.json"
+    payload = json.dumps(data)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(payload)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -273,3 +273,64 @@ class TestMCPStdioCaching:
         r = self._run_mcp("--cache-ttl", "1", "echo", "--message", "refreshed", cache_dir=cd)
         assert r.returncode == 0
         assert "refreshed" in r.stdout
+
+
+class TestCacheCorruptionResilience:
+    """A damaged cache entry must cost one refetch, not every later run."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        import mcp2cli
+        monkeypatch.setattr(mcp2cli, "CACHE_DIR", tmp_path)
+        return mcp2cli
+
+    def test_truncated_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text('{"paths": {"/a"')
+        assert m.load_cached("abc", 3600) is None
+
+    def test_empty_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text("")
+        assert m.load_cached("abc", 3600) is None
+
+    def test_non_utf8_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_bytes(b"\xff\xfe\x00garbage")
+        assert m.load_cached("abc", 3600) is None
+
+    def test_corrupt_entry_is_overwritten_by_the_next_save(
+        self, monkeypatch, tmp_path
+    ):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text("not json at all")
+        assert m.load_cached("abc", 3600) is None
+        m.save_cache("abc", {"paths": {"/pets": {}}})
+        assert m.load_cached("abc", 3600) == {"paths": {"/pets": {}}}
+
+    def test_valid_entry_still_round_trips(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert m.load_cached("abc", 3600) == {"hello": "world"}
+
+    def test_expiry_still_honoured(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert m.load_cached("abc", 0) is None
+
+    def test_save_leaves_no_temp_files_behind(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert [q.name for q in tmp_path.iterdir()] == ["abc.json"]
+
+    def test_failed_serialisation_leaves_previous_entry_intact(
+        self, monkeypatch, tmp_path
+    ):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"good": True})
+        # Serialisation happens before the file is touched, so an
+        # unserialisable payload cannot destroy the entry that is already
+        # on disk.
+        with pytest.raises(TypeError):
+            m.save_cache("abc", {"bad": object()})
+        assert m.load_cached("abc", 3600) == {"good": True}
+        assert [q.name for q in tmp_path.iterdir()] == ["abc.json"]


### PR DESCRIPTION
Fixes #101

## Problem

`load_cached` called `json.loads` unguarded, so a damaged cache entry raised `JSONDecodeError` out of the CLI on every invocation — not just once. Recovery meant knowing `~/.cache/mcp2cli/` exists and working out which sha256-prefixed file to delete. `--refresh` does not help, because the crash is in the read path that runs before the flag is consulted.

`save_cache` is how entries get damaged: `write_text()` is not atomic, so an interrupt on a slow spec fetch, a full disk, or two concurrent runs against the same source can leave a half-written file behind.

## Change

**Read** — `load_cached` treats an unreadable entry as a miss and refetches. This is what `_load_usage()` and `_load_baked_all()` already do; the cache was the odd one out.

**Write** — `save_cache` serialises first, writes to a private temp file in the same directory, then `os.replace()`s it into place. Readers only ever observe the old file or the new one, and a serialisation failure can no longer destroy an entry that was already valid. Temp files are cleaned up on error.

TTL expiry, `--refresh` and `--cache-key` semantics are unchanged.

## Tests

Eight tests in `tests/test_cache.py::TestCacheCorruptionResilience`:

- truncated, empty and non-UTF-8 entries all read as a miss
- a corrupt entry is transparently replaced by the next save
- valid entries still round-trip, and TTL expiry still applies
- a successful save leaves no temp files behind
- an unserialisable payload raises without damaging the entry already on disk

Verified against `main`:

```
--- WITHOUT FIX ---
FAILED TestCacheCorruptionResilience::test_truncated_entry_is_treated_as_a_miss
FAILED TestCacheCorruptionResilience::test_empty_entry_is_treated_as_a_miss
FAILED TestCacheCorruptionResilience::test_non_utf8_entry_is_treated_as_a_miss
FAILED TestCacheCorruptionResilience::test_corrupt_entry_is_overwritten_by_the_next_save
4 failed, 4 passed

--- WITH FIX ---
19 passed
```

Full `tests/test_cache.py`: 19 passed.

## Not included

`_save_usage()` has the same non-atomic write, but its reader already tolerates corruption so the impact is far smaller. Left out to keep this focused — happy to fold it in if you'd rather have one change.
