### PR TITLE
fix(bake): only delete wrappers that `bake install` actually created

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2428,6 +2428,45 @@ def _bake_show(argv: list[str]) -> None:
     print(json.dumps(display, indent=2, ensure_ascii=False))
 
 
+_WRAPPER_MARKER = "# installed by mcp2cli bake install"
+
+
+def _wrapper_is_ours(path: Path) -> bool:
+    """True only for a wrapper script mcp2cli itself wrote."""
+    try:
+        return _WRAPPER_MARKER in path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _remove_installed_wrapper(name: str, cfg: dict) -> None:
+    """Delete the wrapper for *name*, but only if mcp2cli installed it.
+
+    `bake install` records its destination in the config, so a wrapper
+    placed by --dir is found too. Anything we cannot positively identify as
+    ours is left alone and reported: deleting an unrelated executable that
+    merely shares the baked tool's name is far worse than leaving a stale
+    wrapper behind.
+    """
+    recorded = cfg.get("wrapper_path")
+    wrapper = Path(recorded) if recorded else Path.home() / ".local" / "bin" / name
+    if not wrapper.exists():
+        return
+    if not _wrapper_is_ours(wrapper):
+        print(
+            f"Note: left {wrapper} in place -- it was not installed by "
+            f"mcp2cli bake install.",
+            file=sys.stderr,
+        )
+        return
+    try:
+        wrapper.unlink()
+    except OSError as exc:
+        print(f"Warning: could not remove {wrapper}: {exc}", file=sys.stderr)
+        return
+    print(f"Removed installed wrapper: {wrapper}")
+
+
 def _bake_remove(argv: list[str]) -> None:
     p = argparse.ArgumentParser(prog="mcp2cli bake remove")
     p.add_argument("name")
@@ -2436,13 +2475,10 @@ def _bake_remove(argv: list[str]) -> None:
     if args.name not in all_configs:
         print(f"Error: no baked tool named '{args.name}'", file=sys.stderr)
         sys.exit(1)
+    cfg = all_configs[args.name]
     del all_configs[args.name]
     _save_baked_all(all_configs)
-    # Clean up any installed wrapper
-    wrapper = Path.home() / ".local" / "bin" / args.name
-    if wrapper.exists():
-        wrapper.unlink()
-        print(f"Removed installed wrapper: {wrapper}")
+    _remove_installed_wrapper(args.name, cfg)
     print(f"Baked tool '{args.name}' removed.")
 
 
@@ -2495,9 +2531,16 @@ def _bake_install(argv: list[str]) -> None:
     # Resolve mcp2cli path
     mcp2cli_bin = shutil.which("mcp2cli") or "mcp2cli"
     wrapper.write_text(
-        f"#!/bin/sh\nexec {shlex.quote(mcp2cli_bin)} @{args.name} \"$@\"\n"
+        f"#!/bin/sh\n{_WRAPPER_MARKER}\n"
+        f"exec {shlex.quote(mcp2cli_bin)} @{args.name} \"$@\"\n"
     )
     wrapper.chmod(0o755)
+    # Remember where it landed so `bake remove` can find it again, including
+    # when --dir put it somewhere other than ~/.local/bin.
+    all_configs = _load_baked_all()
+    if args.name in all_configs:
+        all_configs[args.name]["wrapper_path"] = str(wrapper)
+        _save_baked_all(all_configs)
     print(f"Installed wrapper: {wrapper}")
     if args.dir is None and str(bin_dir) not in os.environ.get("PATH", ""):
         print(f"  Note: {bin_dir} may not be in your PATH")

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -549,3 +549,110 @@ class TestBakeInstall:
         )
         assert r.returncode == 0
         assert "may not be in your PATH" not in r.stdout
+
+
+class TestBakeRemoveWrapperSafety:
+    """`bake remove` must only delete wrappers mcp2cli itself installed."""
+
+    def _baked(self, monkeypatch, tmp_path, name, extra=None):
+        import mcp2cli
+        cfg_dir = tmp_path / "config"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(mcp2cli, "CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(mcp2cli, "BAKED_FILE", cfg_dir / "baked.json")
+        config = {"source_type": "mcp", "source": "https://example.com/mcp"}
+        config.update(extra or {})
+        mcp2cli._save_baked_all({name: config})
+        return mcp2cli
+
+    def test_foreign_file_with_the_same_name_is_left_alone(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        victim = home / ".local" / "bin" / "jq"
+        victim.write_text("#!/bin/sh\n# the user's own jq\n")
+
+        m = self._baked(monkeypatch, tmp_path, "jq")
+        m._bake_remove(["jq"])
+
+        assert victim.exists()
+        assert "the user's own jq" in victim.read_text()
+        assert m._load_baked("jq") is None
+
+    def test_wrapper_we_installed_is_removed(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool"])
+        wrapper = home / ".local" / "bin" / "mytool"
+        assert wrapper.exists()
+
+        m._bake_remove(["mytool"])
+        assert not wrapper.exists()
+
+    def test_wrapper_installed_with_custom_dir_is_removed(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        wrapper = custom / "mytool"
+        assert wrapper.exists()
+
+        m._bake_remove(["mytool"])
+        assert not wrapper.exists()
+
+    def test_custom_dir_install_does_not_touch_default_dir(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        # An unrelated binary sits at the default location under the same name.
+        decoy = home / ".local" / "bin" / "mytool"
+        decoy.write_text("#!/bin/sh\n# unrelated\n")
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        m._bake_remove(["mytool"])
+
+        assert not (custom / "mytool").exists()
+        assert decoy.exists()
+
+    def test_install_records_the_wrapper_path(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        assert m._load_baked("mytool")["wrapper_path"] == str(custom / "mytool")
+
+    def test_remove_succeeds_when_no_wrapper_was_installed(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_remove(["mytool"])
+        assert m._load_baked("mytool") is None


### PR DESCRIPTION
Fixes #103

## Problem

`_bake_remove` unlinked `~/.local/bin/<name>` unconditionally, with no check that mcp2cli had ever written a file there. Baked names match `[a-z][a-z0-9-]*`, so any ordinary executable qualifies — baking a config named `jq` and later removing it deletes the user's own `~/.local/bin/jq`, even if `bake install` was never run.

The same code also missed the wrappers it was meant to clean up: `bake install --dir ./scripts` writes elsewhere and nothing recorded where, so removal looked only in the default directory. One operation both left the real wrapper behind *and* deleted an unrelated file of the same name.

## Change

- `bake install` writes a marker comment into the generated script and records the destination in the baked config (`wrapper_path`).
- `bake remove` consults that recorded path — so `--dir` installs are found — and unlinks only when the marker is present.
- Anything not positively identifiable as ours is left alone and reported on stderr.
- Unlink errors are reported rather than raised.

## Compatibility

Wrappers written by earlier versions carry no marker, so they are now reported instead of removed. Leaving a stale wrapper is the safer error: the alternative is deleting a binary mcp2cli never owned. Happy to add a fallback heuristic for pre-existing wrappers if you'd prefer.

## Tests

Six tests in `tests/test_bake.py::TestBakeRemoveWrapperSafety`:

- a foreign file sharing the baked name survives removal, with its contents intact
- a wrapper we installed is still removed
- a `--dir` wrapper is found and removed
- a `--dir` install does not touch a same-named decoy in `~/.local/bin`
- `bake install` records the wrapper path
- removing a config with no installed wrapper succeeds cleanly

Verified against `main`:

```
--- WITHOUT FIX ---
FAILED TestBakeRemoveWrapperSafety::test_foreign_file_with_the_same_name_is_left_alone
FAILED TestBakeRemoveWrapperSafety::test_wrapper_installed_with_custom_dir_is_removed
FAILED TestBakeRemoveWrapperSafety::test_custom_dir_install_does_not_touch_default_dir
FAILED TestBakeRemoveWrapperSafety::test_install_records_the_wrapper_path
4 failed, 2 passed

--- WITH FIX ---
42 passed
```

Full `tests/test_bake.py`: 42 passed, including the existing `test_install_creates_wrapper` and `test_install_custom_dir` unchanged.
