### PR TITLE
fix(graphql): dedupe colliding CLI names so a schema cannot brick the CLI

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1883,6 +1883,29 @@ def _build_graphql_param(arg: dict, types_by_name: dict) -> ParamDef:
     )
 
 
+def _unique_graphql_name(
+    name: str, op_type: str, reserved: set[str], used: set[str]
+) -> str:
+    """Return a free CLI name for a GraphQL field.
+
+    The first field to claim a name keeps it. A later collision is
+    disambiguated by the operation type, then by a numeric suffix if that is
+    taken too. A generated alias is never allowed to equal another field's
+    own name, which would make that field unreachable.
+    """
+    if name not in used:
+        return name
+    candidate = f"{op_type}-{name}"
+    if candidate not in reserved and candidate not in used:
+        return candidate
+    suffix = 2
+    while True:
+        numbered = f"{candidate}-{suffix}"
+        if numbered not in reserved and numbered not in used:
+            return numbered
+        suffix += 1
+
+
 def extract_graphql_commands(schema: dict) -> list[CommandDef]:
     """Convert introspection schema into CommandDef list."""
     types_by_name = {t["name"]: t for t in schema.get("types", []) if t.get("name")}
@@ -1891,46 +1914,52 @@ def extract_graphql_commands(schema: dict) -> list[CommandDef]:
     mutation_type_name = (schema.get("mutationType") or {}).get("name")
 
     commands: list[CommandDef] = []
-    seen_names: set[str] = set()
 
     query_fields = types_by_name.get(query_type_name, {}).get("fields", []) if query_type_name else []
     mutation_fields = types_by_name.get(mutation_type_name, {}).get("fields", []) if mutation_type_name else []
     collisions = _detect_field_collisions(query_fields, mutation_fields)
 
-    for op_type, type_name, fields in [
-        ("query", query_type_name, query_fields),
-        ("mutation", mutation_type_name, mutation_fields),
-    ]:
+    # Pass 1: every field's natural CLI name. A field whose *wire* name exists
+    # under both Query and Mutation is prefixed with its operation type on both
+    # sides, which is the pre-existing symmetric naming and is kept as-is.
+    entries: list[tuple[str, str, dict]] = []
+    for op_type, fields in (("query", query_fields), ("mutation", mutation_fields)):
         for field_def in fields:
             field_name = field_def["name"]
             if field_name.startswith("__"):
                 continue
-
-            cli_name = to_kebab(field_name)
+            base = to_kebab(field_name)
             if field_name in collisions:
-                cli_name = f"{op_type}-{cli_name}"
+                base = f"{op_type}-{base}"
+            entries.append((base, op_type, field_def))
 
-            if cli_name in seen_names:
-                cli_name = f"{op_type}-{cli_name}"
-            seen_names.add(cli_name)
+    # Pass 2: allocate against the complete set of natural names, so a
+    # generated alias can never shadow a field that owns that name.
+    reserved = {base for base, _, _ in entries}
+    used: set[str] = set()
 
-            desc = field_def.get("description") or f"{op_type} {field_name}"
-            params = [
-                _build_graphql_param(arg, types_by_name)
-                for arg in field_def.get("args", [])
-            ]
+    for base, op_type, field_def in entries:
+        field_name = field_def["name"]
+        cli_name = _unique_graphql_name(base, op_type, reserved, used)
+        used.add(cli_name)
 
-            commands.append(
-                CommandDef(
-                    name=cli_name,
-                    description=desc,
-                    params=params,
-                    has_body=bool(params),
-                    graphql_operation_type=op_type,
-                    graphql_field_name=field_name,
-                    graphql_return_type=field_def.get("type"),
-                )
+        desc = field_def.get("description") or f"{op_type} {field_name}"
+        params = [
+            _build_graphql_param(arg, types_by_name)
+            for arg in field_def.get("args", [])
+        ]
+
+        commands.append(
+            CommandDef(
+                name=cli_name,
+                description=desc,
+                params=params,
+                has_body=bool(params),
+                graphql_operation_type=op_type,
+                graphql_field_name=field_name,
+                graphql_return_type=field_def.get("type"),
             )
+        )
 
     return commands
 

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,5 +1,6 @@
 """Tests for GraphQL support."""
 
+import argparse
 import json
 import subprocess
 import sys
@@ -394,3 +395,106 @@ class TestGraphQLIntegration:
         assert r.returncode == 0
         data = json.loads(r.stdout)
         assert isinstance(data, list)
+
+
+def _name_collision_schema(query_fields=(), mutation_fields=()):
+    """Minimal introspection schema with the given Query/Mutation field names."""
+    def field(name):
+        return {
+            "name": name,
+            "description": None,
+            "args": [],
+            "type": {"kind": "SCALAR", "name": "String", "ofType": None},
+        }
+
+    return {
+        "queryType": {"name": "Query"},
+        "mutationType": {"name": "Mutation"} if mutation_fields else None,
+        "types": [
+            {
+                "name": "Query",
+                "kind": "OBJECT",
+                "fields": [field(n) for n in query_fields],
+            },
+            {
+                "name": "Mutation",
+                "kind": "OBJECT",
+                "fields": [field(n) for n in mutation_fields],
+            },
+        ],
+    }
+
+
+class TestGraphQLNameCollisions:
+    """Fields that kebab-case onto the same name must stay addressable."""
+
+    def test_three_way_kebab_collision_stays_unique(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "GetUser"]
+        )
+        names = [c.name for c in mcp2cli.extract_graphql_commands(schema)]
+        assert len(names) == len(set(names))
+        assert names == ["get-user", "query-get-user", "query-get-user-2"]
+
+    def test_three_way_collision_builds_a_parser(self):
+        # Duplicate subparser names raise argparse.ArgumentError, which took
+        # down every command rather than just the colliding ones.
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "GetUser"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        parser = mcp2cli.build_argparse(cmds, argparse.ArgumentParser(add_help=False))
+        for cmd in cmds:
+            assert parser.parse_args([cmd.name])._cmd is cmd
+
+    def test_alias_never_shadows_another_fields_natural_name(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "queryGetUser"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        by_field = {c.graphql_field_name: c.name for c in cmds}
+        # queryGetUser owns `query-get-user`; the alias for get_user must
+        # not take it.
+        assert by_field["queryGetUser"] == "query-get-user"
+        assert by_field["getUser"] == "get-user"
+        assert len(set(by_field.values())) == 3
+
+    def test_query_mutation_overlap_still_prefixed_symmetrically(self):
+        schema = _name_collision_schema(
+            query_fields=["user"], mutation_fields=["user"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        assert [c.name for c in cmds] == ["query-user", "mutation-user"]
+
+    def test_cross_type_kebab_collision_is_disambiguated(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser"], mutation_fields=["get_user"]
+        )
+        names = [c.name for c in mcp2cli.extract_graphql_commands(schema)]
+        assert len(names) == len(set(names))
+        assert names == ["get-user", "mutation-get-user"]
+
+    def test_introspection_fields_still_skipped(self):
+        schema = _name_collision_schema(
+            query_fields=["__schema", "__type", "user"]
+        )
+        assert [c.name for c in mcp2cli.extract_graphql_commands(schema)] == ["user"]
+
+    def test_non_colliding_names_are_untouched(self):
+        schema = _name_collision_schema(
+            query_fields=["listUsers"], mutation_fields=["createUser"]
+        )
+        assert [c.name for c in mcp2cli.extract_graphql_commands(schema)] == [
+            "list-users",
+            "create-user",
+        ]
+
+    def test_field_metadata_survives_renaming(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        # The wire name is what actually goes into the document, so it must
+        # be preserved even when the CLI name is aliased.
+        assert [c.graphql_field_name for c in cmds] == ["getUser", "get_user"]
+        assert all(c.graphql_operation_type == "query" for c in cmds)


### PR DESCRIPTION
Fixes #105

## Problem

`extract_graphql_commands` allocated CLI names in a single pass against a running `seen_names` set, so a *second* collision was never resolved:

```
getUser, get_user, GetUser
  ->  ['get-user', 'query-get-user', 'query-get-user']
```

Duplicate subcommand names raise `argparse.ArgumentError`, which takes down every command rather than just the colliding ones.

The same pass could also mint an alias that shadowed a field legitimately owning that name — with `queryGetUser` in the schema, the alias for `get_user` stole `query-get-user` and left the real field unreachable.

## Change

Two-pass allocation, mirroring what `extract_mcp_commands` received in #80/#82:

1. collect every field's natural name,
2. hand out aliases against that complete set, falling back to a numeric suffix when the operation-type prefix is also taken.

`graphql_field_name` is untouched, so the generated document still targets the field the server declared. The existing symmetric `query-`/`mutation-` prefixing for a name present under both root types is preserved as-is.

## Tests

Eight tests in `tests/test_graphql.py::TestGraphQLNameCollisions`:

- three-way kebab collision stays unique
- the parser actually builds and every command round-trips through `parse_args`
- an alias never shadows another field's natural name
- Query/Mutation overlap still prefixed symmetrically (no regression)
- cross-root-type kebab collision disambiguated
- `__schema`/`__type` still skipped
- non-colliding names untouched
- wire name and operation type survive renaming

Verified against `main`:

```
--- WITHOUT FIX ---
FAILED ...::test_three_way_kebab_collision_stays_unique
FAILED ...::test_three_way_collision_builds_a_parser
FAILED ...::test_alias_never_shadows_another_fields_natural_name
3 failed, 5 passed

--- WITH FIX ---
8 passed
```

Full file: `45 passed`.

## Context

Third and last instance of this defect. MCP was fixed in #80/#82; OpenAPI is #97 / PR #98; this is the GraphQL one. Independent of those — different function, no overlap.
