### PR TITLE
docs: bake example used an npm package that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,13 @@ mcp2cli bake create petstore --spec https://api.example.com/spec.json \
   --exclude "delete-*,update-*" --methods GET,POST --cache-ttl 7200
 
 # Create a baked tool from an MCP stdio server
-mcp2cli bake create mygit --mcp-stdio "npx @mcp/github" \
-  --include "search-*,list-*" --exclude "delete-*"
+mcp2cli bake create myfs --mcp-stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" \
+  --include "search-*,list-*" --exclude "list-allowed-*"
 
 # Use a baked tool with @ prefix — no connection flags needed
 mcp2cli @petstore --list
 mcp2cli @petstore list-pets --limit 10
-mcp2cli @mygit search-repos --query "rust"
+mcp2cli @myfs search-files --path /tmp --pattern "*.md"
 
 # Manage baked tools
 mcp2cli bake list                         # show all baked tools

--- a/skills/mcp2cli/SKILL.md
+++ b/skills/mcp2cli/SKILL.md
@@ -257,8 +257,8 @@ Save connection settings as named configurations to avoid repeating flags:
 mcp2cli bake create petstore --spec https://api.example.com/spec.json \
   --exclude "delete-*,update-*" --methods GET,POST --cache-ttl 7200
 
-mcp2cli bake create mygit --mcp-stdio "npx @mcp/github" \
-  --include "search-*,list-*" --exclude "delete-*"
+mcp2cli bake create myfs --mcp-stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" \
+  --include "search-*,list-*" --exclude "list-allowed-*"
 
 # Use with @ prefix
 mcp2cli @petstore --list


### PR DESCRIPTION
i am an AI agent (Claude) working on behalf of Anton Dzyatkovsky, who reviews what i open.

## What was broken

The bake-mode example in `README.md` and in `skills/mcp2cli/SKILL.md` builds its MCP stdio tool
from `npx @mcp/github`. There is no `@mcp/github` package on npm, so the example cannot run.

It does not read as a placeholder, either. The bake example right above it points at
`https://api.example.com/spec.json`, which says "substitute your own"; `npx @mcp/github` reads as
a real package name, and the three `--mcp-stdio` examples earlier in the README already use a real
one (`@modelcontextprotocol/server-filesystem`).

This costs more in `SKILL.md` than in the README: that file is what coding agents read, and an
agent following it runs the command rather than noticing the name is invented.

## How i checked

mcp2cli 3.7.0 via uvx, `MCP2CLI_CONFIG_DIR` pointed at a scratch directory.

The README example, verbatim:

```
$ mcp2cli bake create mygit --mcp-stdio "npx @mcp/github" \
    --include "search-*,list-*" --exclude "delete-*"
Baked tool 'mygit' created.

$ mcp2cli @mygit --list
npm error 404  The requested resource '@mcp/github@*' could not be found or you do not have permission to access it.
Error: cannot use MCP server at npx @mcp/github: Connection closed
```

`bake create` succeeds because it only stores the string; the failure lands at first use, and again
on the documented `mcp2cli @mygit search-repos --query "rust"`. `npm view @mcp/github` returns E404.

## What it says now

The same example, pointed at the server the rest of the README already uses, with an exclude that
does something on that server:

```
$ mcp2cli bake create myfs --mcp-stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" \
    --include "search-*,list-*" --exclude "list-allowed-*"
Baked tool 'myfs' created.

$ mcp2cli @myfs --list
Available tools:
  list-directory                Get a detailed listing of all files and directories ...
  list-directory-with-sizes     Get a detailed listing of all files and directories ...
  search-files                  Recursively search for files and directories matching ...

$ mcp2cli @myfs search-files --path /tmp --pattern "*.md"
(prints the matching paths)
```

The filters are doing visible work there: the server exposes 14 tools, `--include` narrows to 4,
and `--exclude "list-allowed-*"` drops `list-allowed-directories`, leaving 3. The old
`--exclude "delete-*"` matched nothing on any server the docs name. No credentials are needed, so
the example runs exactly as printed.

## Tests

`python -m pytest -q` on the patched tree: 409 passed, 4 failed. The same 4 fail on the untouched
checkout (two `TestToonEncode` cases want the `@toon-format/cli` npm binary that CI installs, two in
`test_mcp.py` are environment-related), so they are unrelated to this change, which touches only
markdown.

`tests/test_bake.py` uses the string `npx @mcp/github` as an opaque config value and never connects,
so i left it alone.
