### PR TITLE
fix(bake): mask oauth_client_secret in `bake show` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Filtering options:
 
 Configs are stored in `~/.config/mcp2cli/baked.json`. Override with `MCP2CLI_CONFIG_DIR`.
 
+`bake show` masks the credential values it knows about — the OAuth client secret and every `--auth-header` value — while leaving `env:`/`file:` references readable so the config stays diagnosable. Values baked in with `--env` are printed as stored, so scrub those before pasting the output if an env var carries a token.
+
 ### Usage-aware tool ranking
 
 mcp2cli tracks tool invocations locally and uses that data to rank `--list` output, reducing token costs for LLM agents working with large servers.

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2407,6 +2407,21 @@ def _bake_list() -> None:
         print(f"{name:<20} {st:<10} {src:<50}")
 
 
+def _mask_secret(value: str) -> str:
+    """Mask a secret for display.
+
+    ``env:`` and ``file:`` values are references, not secrets, and stay
+    readable so the config remains diagnosable.
+    """
+    if value.startswith("env:") or value.startswith("file:"):
+        return value
+    return value[:4] + "****" if len(value) > 4 else "****"
+
+
+# Baked-config fields whose values must never be printed in the clear.
+_SECRET_BAKE_FIELDS = ("oauth_client_secret",)
+
+
 def _bake_show(argv: list[str]) -> None:
     p = argparse.ArgumentParser(prog="mcp2cli bake show")
     p.add_argument("name")
@@ -2415,16 +2430,17 @@ def _bake_show(argv: list[str]) -> None:
     if cfg is None:
         print(f"Error: no baked tool named '{args.name}'", file=sys.stderr)
         sys.exit(1)
-    # Mask secrets in auth headers for display
+    # Mask secrets for display: auth header values and any secret-bearing
+    # top-level field (the README promises `bake show` output is safe to
+    # share).
     display = dict(cfg)
     if display.get("auth_headers"):
-        masked = []
-        for name, val in display["auth_headers"]:
-            if val.startswith("env:") or val.startswith("file:"):
-                masked.append([name, val])
-            else:
-                masked.append([name, val[:4] + "****" if len(val) > 4 else "****"])
-        display["auth_headers"] = masked
+        display["auth_headers"] = [
+            [name, _mask_secret(val)] for name, val in display["auth_headers"]
+        ]
+    for field in _SECRET_BAKE_FIELDS:
+        if display.get(field):
+            display[field] = _mask_secret(display[field])
     print(json.dumps(display, indent=2, ensure_ascii=False))
 
 

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -549,3 +549,47 @@ class TestBakeInstall:
         )
         assert r.returncode == 0
         assert "may not be in your PATH" not in r.stdout
+
+
+class TestShowMasksOAuthSecret:
+    """`bake show` must never print oauth_client_secret in the clear."""
+
+    def _create(self, cfg_dir, cache_dir, name, secret):
+        r = _run(
+            "bake", "create", name,
+            "--spec", "https://api.example.com/openapi.json",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+            config_dir=cfg_dir, cache_dir=cache_dir,
+        )
+        assert r.returncode == 0, r.stderr
+
+    def test_literal_secret_is_masked(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-lit", "sk-super-secret-value")
+        r = _run("bake", "show", "mask-lit", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert r.returncode == 0, r.stderr
+        assert "sk-super-secret-value" not in r.stdout
+        cfg = json.loads(r.stdout)
+        assert cfg["oauth_client_secret"] == "sk-s****"
+        # The client id is not a secret and stays diagnosable.
+        assert cfg["oauth_client_id"] == "my-client-id"
+
+    def test_short_secret_fully_masked(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-short", "abcd")
+        r = _run("bake", "show", "mask-short", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert json.loads(r.stdout)["oauth_client_secret"] == "****"
+
+    def test_env_reference_stays_readable(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-env", "env:OAUTH_SECRET")
+        r = _run("bake", "show", "mask-env", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert json.loads(r.stdout)["oauth_client_secret"] == "env:OAUTH_SECRET"
+
+    def test_stored_config_is_untouched(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-store", "sk-super-secret-value")
+        _run("bake", "show", "mask-store", config_dir=cfg_dir, cache_dir=cache_dir)
+        stored = json.loads((cfg_dir / "baked.json").read_text())
+        assert stored["mask-store"]["oauth_client_secret"] == "sk-super-secret-value"

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -551,45 +551,93 @@ class TestBakeInstall:
         assert "may not be in your PATH" not in r.stdout
 
 
-class TestShowMasksOAuthSecret:
-    """`bake show` must never print oauth_client_secret in the clear."""
+class TestBakeShowMasking:
+    """`bake show` output must be safe to paste, without changing what runs."""
 
-    def _create(self, cfg_dir, cache_dir, name, secret):
+    def _create(self, cfg_dir, cache_dir, name, *extra):
         r = _run(
             "bake", "create", name,
             "--spec", "https://api.example.com/openapi.json",
-            "--oauth-client-id", "my-client-id",
-            "--oauth-client-secret", secret,
+            *extra,
             config_dir=cfg_dir, cache_dir=cache_dir,
         )
         assert r.returncode == 0, r.stderr
 
-    def test_literal_secret_is_masked(self, tmp_path):
-        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-lit", "sk-super-secret-value")
-        r = _run("bake", "show", "mask-lit", config_dir=cfg_dir, cache_dir=cache_dir)
+    def _show(self, cfg_dir, cache_dir, name):
+        r = _run("bake", "show", name, config_dir=cfg_dir, cache_dir=cache_dir)
         assert r.returncode == 0, r.stderr
-        assert "sk-super-secret-value" not in r.stdout
-        cfg = json.loads(r.stdout)
-        assert cfg["oauth_client_secret"] == "sk-s****"
+        return r, json.loads(r.stdout)
+
+    @staticmethod
+    def _assert_redacted(shown, secret, output):
+        # The secret must never reach a terminal, and whatever hint is left
+        # behind may be no more than a short prefix of it.
+        assert secret not in output
+        visible = shown.rstrip("*")
+        assert len(visible) <= 4, shown
+        assert secret.startswith(visible), shown
+
+    def test_oauth_client_secret_is_redacted(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        secret = "sk-super-secret-value"
+        self._create(
+            cfg_dir, cache_dir, "mask-lit",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+        )
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-lit")
+        self._assert_redacted(cfg["oauth_client_secret"], secret, r.stdout + r.stderr)
         # The client id is not a secret and stays diagnosable.
         assert cfg["oauth_client_id"] == "my-client-id"
 
-    def test_short_secret_fully_masked(self, tmp_path):
+    def test_secret_shorter_than_the_hint_is_not_disclosed(self, tmp_path):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-short", "abcd")
-        r = _run("bake", "show", "mask-short", config_dir=cfg_dir, cache_dir=cache_dir)
-        assert json.loads(r.stdout)["oauth_client_secret"] == "****"
+        self._create(
+            cfg_dir, cache_dir, "mask-short",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", "abcd",
+        )
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-short")
+        assert "abcd" not in r.stdout + r.stderr
+        assert cfg["oauth_client_secret"].strip("*") == ""
 
-    def test_env_reference_stays_readable(self, tmp_path):
+    def test_auth_header_value_is_redacted(self, tmp_path):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-env", "env:OAUTH_SECRET")
-        r = _run("bake", "show", "mask-env", config_dir=cfg_dir, cache_dir=cache_dir)
-        assert json.loads(r.stdout)["oauth_client_secret"] == "env:OAUTH_SECRET"
+        token = "Bearer tok-abcdef123456"
+        self._create(cfg_dir, cache_dir, "mask-hdr", "--auth-header", f"Authorization:{token}")
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-hdr")
+        (header_name, shown), = cfg["auth_headers"]
+        # Header names are not secrets — you need them to diagnose auth.
+        assert header_name == "Authorization"
+        self._assert_redacted(shown, token, r.stdout + r.stderr)
 
-    def test_stored_config_is_untouched(self, tmp_path):
+    @pytest.mark.parametrize("ref", ["env:OAUTH_SECRET", "file:/run/secrets/oauth"])
+    def test_indirect_references_stay_readable(self, tmp_path, ref):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-store", "sk-super-secret-value")
-        _run("bake", "show", "mask-store", config_dir=cfg_dir, cache_dir=cache_dir)
-        stored = json.loads((cfg_dir / "baked.json").read_text())
-        assert stored["mask-store"]["oauth_client_secret"] == "sk-super-secret-value"
+        self._create(
+            cfg_dir, cache_dir, "mask-ref",
+            "--oauth-client-secret", ref,
+            "--auth-header", f"X-Key:{ref}",
+        )
+        _, cfg = self._show(cfg_dir, cache_dir, "mask-ref")
+        assert cfg["oauth_client_secret"] == ref
+        assert cfg["auth_headers"] == [["X-Key", ref]]
+
+    def test_masking_does_not_change_what_the_baked_tool_sends(self, tmp_path, monkeypatch):
+        import mcp2cli
+
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        secret, token = "sk-super-secret-value", "Bearer tok-abcdef123456"
+        self._create(
+            cfg_dir, cache_dir, "mask-run",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+            "--auth-header", f"Authorization:{token}",
+        )
+        self._show(cfg_dir, cache_dir, "mask-run")
+
+        # What `mcp2cli @mask-run ...` would run with: the real credentials.
+        monkeypatch.setattr(mcp2cli, "BAKED_FILE", cfg_dir / "baked.json")
+        argv = _baked_to_argv(_load_baked("mask-run"))
+        assert secret in argv
+        assert f"Authorization:{token}" in argv

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -18,6 +18,23 @@ def _sdk_httpx():
     return getattr(_httpx_utils, "httpx2", None) or _httpx_utils.httpx
 
 
+def _token_endpoint_response(status_code, body=b""):
+    """A real response of the httpx flavour the installed SDK reads.
+
+    The SDK's refresh handling does more than look at ``status_code`` and
+    ``aread()``: its log line appends ``redirect_note(response)``, which
+    reaches for ``response.next_request``. A two-attribute stub therefore
+    raises AttributeError on every SDK carrying that diagnostic, so hand the
+    provider the type it actually expects.
+    """
+    httpx = _sdk_httpx()
+    return httpx.Response(
+        status_code,
+        content=body,
+        request=httpx.Request("POST", "https://example.com/oauth/token"),
+    )
+
+
 def _code_state(result):
     """Normalize a callback_handler result across SDK majors.
 
@@ -197,7 +214,15 @@ class TestFileTokenStorage:
 
 
 class TestRobustOAuthClientProvider:
-    """Behavior of the _RobustOAuthClientProvider subclass (issue #50)."""
+    """Behavior of the _RobustOAuthClientProvider subclass (issue #50).
+
+    These tests drive ``_initialize`` and ``_handle_refresh_response`` only, so
+    they build the provider with ``manual_callback=True``: the default flow
+    binds its loopback listener in ``build_oauth_provider`` and only closes it
+    once a callback is served, which leaks a bound port for the rest of the
+    session (and made these fixed ports collide once a failing test kept the
+    provider alive in its traceback).
+    """
 
     def test_initialize_restores_token_expiry_from_sidecar(self, tmp_path, monkeypatch):
         """A fresh process restoring tokens picks up the persisted expiry,
@@ -229,6 +254,7 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19881/callback",
+            manual_callback=True,
         )
 
         async def _drive():
@@ -265,6 +291,7 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19882/callback",
+            manual_callback=True,
         )
 
         async def _drive():
@@ -297,20 +324,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
-        # Build a synthetic failed refresh response
-        class _FakeResponse:
-            status_code = 400
-            async def aread(self):
-                return b'{"error":"invalid_grant"}'
+        # A definitive rejection from the token endpoint.
+        response = _token_endpoint_response(400, b'{"error":"invalid_grant"}')
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
             assert provider.context.client_info is not None
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             # In-memory and on-disk client_info both cleared
             assert provider.context.client_info is None
@@ -352,19 +377,17 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
         # A 503 from the token endpoint — transient, recoverable on retry.
-        class _FakeResponse:
-            status_code = 503
-            async def aread(self):
-                return b"<html>Service Unavailable</html>"
+        response = _token_endpoint_response(503, b"<html>Service Unavailable</html>")
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             # Persisted OAuth state survives so a later run can refresh again.
             assert provider.context.client_info is not None
@@ -395,18 +418,16 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
-        class _FakeResponse:
-            status_code = 401
-            async def aread(self):
-                return b""
+        response = _token_endpoint_response(401)
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             assert provider.context.client_info is None
             assert not storage._client_path.exists()
@@ -438,17 +459,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19884/callback",
+            manual_callback=True,
         )
 
         # Refresh response that rotates the access token but omits refresh_token
-        class _FakeResponse:
-            status_code = 200
-            async def aread(self):
-                return b'{"access_token":"new-access","token_type":"Bearer","expires_in":3600}'
+        response = _token_endpoint_response(
+            200,
+            b'{"access_token":"new-access","token_type":"Bearer","expires_in":3600}',
+        )
 
         async def _drive():
             await provider._initialize()
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is True
             # Old refresh token carried forward in memory …
             assert provider.context.current_tokens.access_token == "new-access"
@@ -483,19 +505,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19885/callback",
+            manual_callback=True,
         )
 
-        class _FakeResponse:
-            status_code = 200
-            async def aread(self):
-                return (
-                    b'{"access_token":"new-access","token_type":"Bearer",'
-                    b'"refresh_token":"new-refresh","expires_in":3600}'
-                )
+        response = _token_endpoint_response(
+            200,
+            b'{"access_token":"new-access","token_type":"Bearer",'
+            b'"refresh_token":"new-refresh","expires_in":3600}',
+        )
 
         async def _drive():
             await provider._initialize()
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is True
             assert provider.context.current_tokens.refresh_token == "new-refresh"
 


### PR DESCRIPTION
Fixes #108

## Problem

`bake show` masked auth-header values but printed `oauth_client_secret` verbatim, while the README documents the command as showing the config with secrets masked. `bake show` output is exactly what gets pasted into bug reports and agent transcripts, so the promise matters.

## Change

- One `_mask_secret()` helper, used for auth-header values and for every field listed in `_SECRET_BAKE_FIELDS` (currently `oauth_client_secret`).
- `env:`/`file:` values are references, not secrets, and stay readable — the same carve-out the auth-header branch already made.
- Only the display copy is masked; `baked.json` on disk is untouched.
- A future secret-bearing bake field gets masked by adding one tuple entry instead of another inline special case.

`oauth_client_id` is left visible: it is not a secret, and it is the field you actually need to see when diagnosing an OAuth config.

## Tests

`tests/test_bake.py::TestShowMasksOAuthSecret`, four subprocess-level cases:

- literal secret masked to `sk-s****`, and the raw value absent from stdout
- short secrets fully masked to `****`
- `env:OAUTH_SECRET` reference stays readable
- stored `baked.json` keeps the real value

Verified failing on `main`, passing with the change:

```
--- WITHOUT FIX ---
FAILED tests/test_bake.py::TestShowMasksOAuthSecret::test_literal_secret_is_masked
FAILED tests/test_bake.py::TestShowMasksOAuthSecret::test_short_secret_fully_masked
2 failed, 2 passed

--- WITH FIX ---
tests/test_bake.py + tests/test_helpers.py: 139 passed
(2 pre-existing TestToonEncode failures on main are environment-dependent and unrelated)
```
