### PR TITLE
fix(openapi): survive dangling $refs and decode JSON Pointer escapes

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1341,8 +1341,36 @@ def build_oauth_provider(
 # ---------------------------------------------------------------------------
 
 
+def _json_pointer_unescape(token: str) -> str:
+    """Decode RFC 6901 escapes: ``~1`` is ``/`` and ``~0`` is ``~``.
+
+    Order matters -- ``~1`` first, or ``~01`` would wrongly become ``/``.
+    """
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _json_pointer_lookup(root, pointer_tokens: list[str]):
+    """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
+    target = root
+    for raw in pointer_tokens:
+        token = _json_pointer_unescape(raw)
+        if isinstance(target, dict):
+            if token not in target:
+                raise LookupError(token)
+            target = target[token]
+        elif isinstance(target, list):
+            try:
+                target = target[int(token)]
+            except (ValueError, IndexError):
+                raise LookupError(token) from None
+        else:
+            raise LookupError(token)
+    return target
+
+
 def resolve_refs(spec: dict) -> dict:
     spec = copy.deepcopy(spec)
+    warned: set[str] = set()
 
     def _resolve(node, root, seen):
         if isinstance(node, dict):
@@ -1352,10 +1380,21 @@ def resolve_refs(spec: dict) -> dict:
                     return node
                 seen = seen | {ref}
                 if ref.startswith("#/"):
-                    parts = ref[2:].split("/")
-                    target = root
-                    for p in parts:
-                        target = target[p]
+                    try:
+                        target = _json_pointer_lookup(root, ref[2:].split("/"))
+                    except LookupError:
+                        # A dangling reference in a spec we did not write must
+                        # not take down the CLI. Leave the node unresolved --
+                        # the same shape external refs and cycles already
+                        # produce -- and say so once.
+                        if ref not in warned:
+                            warned.add(ref)
+                            print(
+                                f"Warning: unresolvable $ref {ref!r} in spec; "
+                                "leaving it unresolved.",
+                                file=sys.stderr,
+                            )
+                        return node
                     return _resolve(copy.deepcopy(target), root, seen)
                 return node
             return {k: _resolve(v, root, seen) for k, v in node.items()}

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -27,7 +27,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from datetime import datetime, timezone
 
@@ -1349,22 +1349,61 @@ def _json_pointer_unescape(token: str) -> str:
     return token.replace("~1", "/").replace("~0", "~")
 
 
+def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
+    """Candidate decodings of one reference token, most literal first.
+
+    A ``$ref`` is a URI, so RFC 6901 section 6 percent-encodes the pointer it
+    carries in the fragment: a legal reference to a schema named ``Pet Dog``
+    arrives as ``Pet%20Dog``, and a path item ``/pets/{id}`` as
+    ``~1pets~1%7Bid%7D``. Percent-decoding runs first, since it was applied
+    over the ``~`` escaping. Plenty of hand-written specs skip the encoding
+    step, so the literal token is tried before the decoded one -- a component
+    genuinely named ``Pet%20Dog`` still resolves, and specs that encoded
+    nothing behave exactly as they did before.
+    """
+    literal = _json_pointer_unescape(raw)
+    decoded = _json_pointer_unescape(unquote(raw))
+    return (literal,) if decoded == literal else (literal, decoded)
+
+
+# RFC 6901: an array index is "0", or a digit string with no leading zero.
+# ``int()`` is far more generous -- it accepts "-1" (which would silently
+# select the *last* element), "+1", "01", " 1 ", "1_0" and Unicode digits --
+# so a token is screened before conversion.
+_ARRAY_INDEX_RE = re.compile(r"0|[1-9][0-9]*")
+# No list holds 10**19 items, so a longer digit run is out of range by
+# inspection. Checking the length first also keeps a pathological token away
+# from int(), whose behaviour on huge digit strings hangs on CPython's
+# integer-string conversion limit rather than on anything we control.
+_ARRAY_INDEX_MAX_DIGITS = 19
+
+
+def _array_index(token: str, length: int) -> int | None:
+    """Index *token* addresses in a list of *length*, or None if it does not."""
+    if len(token) > _ARRAY_INDEX_MAX_DIGITS or not _ARRAY_INDEX_RE.fullmatch(token):
+        return None
+    index = int(token)
+    return index if index < length else None
+
+
 def _json_pointer_lookup(root, pointer_tokens: list[str]):
     """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
     target = root
     for raw in pointer_tokens:
-        token = _json_pointer_unescape(raw)
-        if isinstance(target, dict):
-            if token not in target:
-                raise LookupError(token)
-            target = target[token]
-        elif isinstance(target, list):
-            try:
-                target = target[int(token)]
-            except (ValueError, IndexError):
-                raise LookupError(token) from None
+        for token in _json_pointer_tokens(raw):
+            if isinstance(target, dict):
+                if token in target:
+                    target = target[token]
+                    break
+            elif isinstance(target, list):
+                index = _array_index(token, len(target))
+                if index is not None:
+                    target = target[index]
+                    break
+            else:
+                raise LookupError(raw)
         else:
-            raise LookupError(token)
+            raise LookupError(raw)
     return target
 
 
@@ -1389,8 +1428,12 @@ def resolve_refs(spec: dict) -> dict:
                         # produce -- and say so once.
                         if ref not in warned:
                             warned.add(ref)
+                            # A ref is spec-controlled and can be arbitrarily
+                            # long, so keep the diagnostic to one readable
+                            # line instead of echoing the whole token.
+                            shown = ref if len(ref) <= 200 else ref[:200] + "..."
                             print(
-                                f"Warning: unresolvable $ref {ref!r} in spec; "
+                                f"Warning: unresolvable $ref {shown!r} in spec; "
                                 "leaving it unresolved.",
                                 file=sys.stderr,
                             )

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1349,21 +1349,17 @@ def _json_pointer_unescape(token: str) -> str:
     return token.replace("~1", "/").replace("~0", "~")
 
 
-def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
-    """Candidate decodings of one reference token, most literal first.
+def _json_pointer_tokens(fragment: str) -> list[str]:
+    """Split a URI fragment into decoded JSON Pointer reference tokens.
 
     A ``$ref`` is a URI, so RFC 6901 section 6 percent-encodes the pointer it
-    carries in the fragment: a legal reference to a schema named ``Pet Dog``
-    arrives as ``Pet%20Dog``, and a path item ``/pets/{id}`` as
-    ``~1pets~1%7Bid%7D``. Percent-decoding runs first, since it was applied
-    over the ``~`` escaping. Plenty of hand-written specs skip the encoding
-    step, so the literal token is tried before the decoded one -- a component
-    genuinely named ``Pet%20Dog`` still resolves, and specs that encoded
-    nothing behave exactly as they did before.
+    carries in the fragment. Decoding therefore unwinds the two layers in the
+    order they were applied: percent-decode the whole fragment first, then
+    split on the ``/`` separators it now spells out, then decode the ``~``
+    escapes the encoding was applied over. A member name holding a ``/`` is
+    ``~1`` (or ``%7E1``), a ``~`` is ``~0``, and a literal ``%`` is ``%25``.
     """
-    literal = _json_pointer_unescape(raw)
-    decoded = _json_pointer_unescape(unquote(raw))
-    return (literal,) if decoded == literal else (literal, decoded)
+    return [_json_pointer_unescape(t) for t in unquote(fragment).split("/")]
 
 
 # RFC 6901: an array index is "0", or a digit string with no leading zero.
@@ -1371,39 +1367,38 @@ def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
 # select the *last* element), "+1", "01", " 1 ", "1_0" and Unicode digits --
 # so a token is screened before conversion.
 _ARRAY_INDEX_RE = re.compile(r"0|[1-9][0-9]*")
-# No list holds 10**19 items, so a longer digit run is out of range by
-# inspection. Checking the length first also keeps a pathological token away
-# from int(), whose behaviour on huge digit strings hangs on CPython's
-# integer-string conversion limit rather than on anything we control.
-_ARRAY_INDEX_MAX_DIGITS = 19
 
 
 def _array_index(token: str, length: int) -> int | None:
     """Index *token* addresses in a list of *length*, or None if it does not."""
-    if len(token) > _ARRAY_INDEX_MAX_DIGITS or not _ARRAY_INDEX_RE.fullmatch(token):
+    if not length or not _ARRAY_INDEX_RE.fullmatch(token):
         return None
-    index = int(token)
-    return index if index < length else None
+    # Both strings are canonical decimals, so (width, lexicographic) orders
+    # them numerically. Comparing them before converting keeps a spec from
+    # handing int() an arbitrarily long digit run, where CPython's
+    # integer-string conversion limit -- which a host may raise or disable --
+    # would decide what happens instead of us.
+    largest = str(length - 1)
+    if (len(token), token) > (len(largest), largest):
+        return None
+    return int(token)
 
 
-def _json_pointer_lookup(root, pointer_tokens: list[str]):
-    """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
+def _json_pointer_lookup(root, tokens: list[str]):
+    """Walk *root* by decoded pointer tokens. Raises LookupError on a dangle."""
     target = root
-    for raw in pointer_tokens:
-        for token in _json_pointer_tokens(raw):
-            if isinstance(target, dict):
-                if token in target:
-                    target = target[token]
-                    break
-            elif isinstance(target, list):
-                index = _array_index(token, len(target))
-                if index is not None:
-                    target = target[index]
-                    break
-            else:
-                raise LookupError(raw)
+    for token in tokens:
+        if isinstance(target, dict):
+            if token not in target:
+                raise LookupError(token)
+            target = target[token]
+        elif isinstance(target, list):
+            index = _array_index(token, len(target))
+            if index is None:
+                raise LookupError(token)
+            target = target[index]
         else:
-            raise LookupError(raw)
+            raise LookupError(token)
     return target
 
 
@@ -1420,7 +1415,9 @@ def resolve_refs(spec: dict) -> dict:
                 seen = seen | {ref}
                 if ref.startswith("#/"):
                     try:
-                        target = _json_pointer_lookup(root, ref[2:].split("/"))
+                        target = _json_pointer_lookup(
+                            root, _json_pointer_tokens(ref[2:])
+                        )
                     except LookupError:
                         # A dangling reference in a spec we did not write must
                         # not take down the CLI. Leave the node unresolved --
@@ -1428,12 +1425,8 @@ def resolve_refs(spec: dict) -> dict:
                         # produce -- and say so once.
                         if ref not in warned:
                             warned.add(ref)
-                            # A ref is spec-controlled and can be arbitrarily
-                            # long, so keep the diagnostic to one readable
-                            # line instead of echoing the whole token.
-                            shown = ref if len(ref) <= 200 else ref[:200] + "..."
                             print(
-                                f"Warning: unresolvable $ref {shown!r} in spec; "
+                                f"Warning: unresolvable $ref {ref!r} in spec; "
                                 "leaving it unresolved.",
                                 file=sys.stderr,
                             )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -810,3 +810,68 @@ class TestExtractContentParts:
             {"type": "resource_link", "uri": "probe://linked", "name": "linked-doc"},
         ]
         assert _extract_content_parts(blocks) == "see:\nlinked-doc: probe://linked"
+
+
+class TestResolveRefsRobustness:
+    """A spec we did not write must not crash ref resolution."""
+
+    def test_dangling_ref_does_not_raise(self, capsys):
+        spec = {
+            "paths": {
+                "/x": {
+                    "get": {
+                        "parameters": [
+                            {"$ref": "#/components/parameters/Missing"}
+                        ]
+                    }
+                }
+            },
+        }
+        resolved = resolve_refs(spec)
+        # Left unresolved -- the same shape a cycle or external ref produces.
+        assert resolved["paths"]["/x"]["get"]["parameters"][0] == {
+            "$ref": "#/components/parameters/Missing"
+        }
+        err = capsys.readouterr().err
+        assert "unresolvable $ref" in err
+        assert "#/components/parameters/Missing" in err
+
+    def test_dangling_ref_warns_once(self, capsys):
+        ref = {"$ref": "#/nope"}
+        spec = {"paths": {"/a": {"get": {"x": dict(ref)}},
+                          "/b": {"get": {"x": dict(ref)}}}}
+        resolve_refs(spec)
+        assert capsys.readouterr().err.count("unresolvable $ref") == 1
+
+    def test_json_pointer_escapes_are_decoded(self):
+        # RFC 6901: ~1 -> /  and  ~0 -> ~
+        spec = {
+            "components": {"a/b": {"c~d": {"type": "integer"}}},
+            "paths": {
+                "/x": {
+                    "get": {
+                        "schema": {"$ref": "#/components/a~1b/c~0d"}
+                    }
+                }
+            },
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+
+    def test_array_index_tokens(self):
+        spec = {
+            "shared": [{"type": "string"}, {"type": "integer"}],
+            "paths": {
+                "/x": {"get": {"schema": {"$ref": "#/shared/1"}}}
+            },
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+
+    def test_ref_through_non_container_is_unresolved(self):
+        spec = {
+            "leaf": 42,
+            "paths": {"/x": {"get": {"schema": {"$ref": "#/leaf/deeper"}}}},
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"$ref": "#/leaf/deeper"}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -893,7 +893,7 @@ class TestResolveRefsRobustness:
         spec = self._spec("#/shared/2", shared=[{"type": "string"}])
         assert self._schema(resolve_refs(spec)) == {"$ref": "#/shared/2"}
 
-    def test_huge_index_token_does_not_depend_on_int_limit(self, capsys):
+    def test_huge_index_token_does_not_depend_on_int_limit(self):
         ref = "#/shared/" + "9" * 6000
         spec = self._spec(ref, shared=[{"type": "string"}])
         limit = sys.get_int_max_str_digits()
@@ -903,9 +903,6 @@ class TestResolveRefsRobustness:
         finally:
             sys.set_int_max_str_digits(limit)
         assert self._schema(resolved) == {"$ref": ref}
-        # A spec-controlled ref must not flood stderr with one huge line.
-        err = capsys.readouterr().err
-        assert 0 < len(err) < 400, len(err)
 
     def test_numeric_and_signed_dict_keys_still_resolve(self):
         # Array-index screening must not reach dict keys, which are plain
@@ -941,15 +938,28 @@ class TestResolveRefsRobustness:
         }
         assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
-    def test_literal_percent_name_wins_over_decoded_one(self):
+    def test_percent_decoding_is_the_only_reading_of_a_fragment(self):
+        # Both names exist, so the ref is only unambiguous because the
+        # fragment is decoded exactly once: %20 is a space, and a literal
+        # '%' has to arrive as %25.
+        components = {
+            "Pet%20Dog": {"type": "integer"},
+            "Pet Dog": {"type": "string"},
+        }
+        spec = self._spec("#/components/Pet%20Dog", components=components)
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
+        spec = self._spec("#/components/Pet%2520Dog", components=components)
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_encoded_separator_is_a_separator(self):
+        # %2F decodes to a separator, not to a slash inside a member name --
+        # a name holding a slash is ~1 (or %7E1).
         spec = self._spec(
-            "#/components/Pet%20Dog",
-            components={
-                "Pet%20Dog": {"type": "integer"},
-                "Pet Dog": {"type": "string"},
-            },
+            "#/components%2Fa/b", components={"a": {"b": {"type": "integer"}}}
         )
         assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        spec = self._spec("#/components/a%7E1b", components={"a/b": {"type": "string"}})
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
 
     def test_ref_through_non_container_is_unresolved(self):
         spec = self._spec("#/leaf/deeper", leaf=42)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import shutil
+import sys
 
 from mcp2cli import (
     ParamDef,
@@ -815,7 +816,16 @@ class TestExtractContentParts:
 class TestResolveRefsRobustness:
     """A spec we did not write must not crash ref resolution."""
 
-    def test_dangling_ref_does_not_raise(self, capsys):
+    @staticmethod
+    def _spec(ref, **root):
+        """A spec whose only ``$ref`` sits at paths./x.get.schema."""
+        return {"paths": {"/x": {"get": {"schema": {"$ref": ref}}}}, **root}
+
+    @staticmethod
+    def _schema(resolved):
+        return resolved["paths"]["/x"]["get"]["schema"]
+
+    def test_dangling_ref_is_left_unresolved_and_named(self, capsys):
         spec = {
             "paths": {
                 "/x": {
@@ -832,46 +842,120 @@ class TestResolveRefsRobustness:
         assert resolved["paths"]["/x"]["get"]["parameters"][0] == {
             "$ref": "#/components/parameters/Missing"
         }
-        err = capsys.readouterr().err
-        assert "unresolvable $ref" in err
-        assert "#/components/parameters/Missing" in err
+        assert "#/components/parameters/Missing" in capsys.readouterr().err
 
-    def test_dangling_ref_warns_once(self, capsys):
+    def test_dangling_ref_reported_once_per_ref(self, capsys):
         ref = {"$ref": "#/nope"}
         spec = {"paths": {"/a": {"get": {"x": dict(ref)}},
                           "/b": {"get": {"x": dict(ref)}}}}
         resolve_refs(spec)
-        assert capsys.readouterr().err.count("unresolvable $ref") == 1
+        assert capsys.readouterr().err.count("#/nope") == 1
+
+    def test_resolvable_ref_is_silent(self, capsys):
+        spec = self._spec("#/components/Ok", components={"Ok": {"type": "integer"}})
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        assert capsys.readouterr().err == ""
 
     def test_json_pointer_escapes_are_decoded(self):
         # RFC 6901: ~1 -> /  and  ~0 -> ~
-        spec = {
-            "components": {"a/b": {"c~d": {"type": "integer"}}},
-            "paths": {
-                "/x": {
-                    "get": {
-                        "schema": {"$ref": "#/components/a~1b/c~0d"}
-                    }
-                }
-            },
-        }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+        spec = self._spec(
+            "#/components/a~1b/c~0d",
+            components={"a/b": {"c~d": {"type": "integer"}}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
-    def test_array_index_tokens(self):
+    def test_tilde_escape_decoding_order(self):
+        # ~01 is the literal name "~1", never the separator "/".
+        spec = self._spec(
+            "#/components/~01",
+            components={"~1": {"type": "integer"}, "/": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_array_index_tokens_resolve(self):
+        shared = [{"type": "string"}, {"type": "integer"}]
+        assert self._schema(
+            resolve_refs(self._spec("#/shared/0", shared=shared))
+        ) == {"type": "string"}
+        assert self._schema(
+            resolve_refs(self._spec("#/shared/1", shared=shared))
+        ) == {"type": "integer"}
+
+    def test_malformed_array_indices_select_nothing(self):
+        # int() would take every one of these -- "-1" would hand back the
+        # *last* element, "01"/" 1"/"1_0"/"\u0661" some other element.
+        for token in ["-1", "+1", "01", " 1", "1 ", "1_0", "\u0661", "1.0", ""]:
+            ref = f"#/shared/{token}"
+            spec = self._spec(ref, shared=[{"type": "string"}, {"type": "integer"}])
+            assert self._schema(resolve_refs(spec)) == {"$ref": ref}, token
+
+    def test_out_of_range_array_index_selects_nothing(self):
+        spec = self._spec("#/shared/2", shared=[{"type": "string"}])
+        assert self._schema(resolve_refs(spec)) == {"$ref": "#/shared/2"}
+
+    def test_huge_index_token_does_not_depend_on_int_limit(self, capsys):
+        ref = "#/shared/" + "9" * 6000
+        spec = self._spec(ref, shared=[{"type": "string"}])
+        limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(0)  # 0 disables CPython's conversion guard
+        try:
+            resolved = resolve_refs(spec)
+        finally:
+            sys.set_int_max_str_digits(limit)
+        assert self._schema(resolved) == {"$ref": ref}
+        # A spec-controlled ref must not flood stderr with one huge line.
+        err = capsys.readouterr().err
+        assert 0 < len(err) < 400, len(err)
+
+    def test_numeric_and_signed_dict_keys_still_resolve(self):
+        # Array-index screening must not reach dict keys, which are plain
+        # strings: OpenAPI response maps are keyed "200", "404", ...
+        spec = self._spec(
+            "#/responses/200",
+            responses={"200": {"type": "integer"}, "-1": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        spec = self._spec(
+            "#/responses/-1",
+            responses={"200": {"type": "integer"}, "-1": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
+
+    def test_percent_encoded_fragment_resolves(self):
+        # RFC 6901 section 6: a pointer inside a URI fragment is
+        # percent-encoded, so a space arrives as %20 and "{" as %7B.
+        spec = self._spec(
+            "#/components/Pet%20Dog",
+            components={"Pet Dog": {"type": "integer"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        # "{" and "}" are not legal fragment characters either, so a legal
+        # ref to a templated path item arrives as ~1pets~1%7Bid%7D.
         spec = {
-            "shared": [{"type": "string"}, {"type": "integer"}],
             "paths": {
-                "/x": {"get": {"schema": {"$ref": "#/shared/1"}}}
-            },
+                "/pets/{id}": {"get": {"type": "integer"}},
+                "/x": {
+                    "get": {"schema": {"$ref": "#/paths/~1pets~1%7Bid%7D/get"}}
+                },
+            }
         }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_literal_percent_name_wins_over_decoded_one(self):
+        spec = self._spec(
+            "#/components/Pet%20Dog",
+            components={
+                "Pet%20Dog": {"type": "integer"},
+                "Pet Dog": {"type": "string"},
+            },
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
     def test_ref_through_non_container_is_unresolved(self):
-        spec = {
-            "leaf": 42,
-            "paths": {"/x": {"get": {"schema": {"$ref": "#/leaf/deeper"}}}},
-        }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"$ref": "#/leaf/deeper"}
+        spec = self._spec("#/leaf/deeper", leaf=42)
+        assert self._schema(resolve_refs(spec)) == {"$ref": "#/leaf/deeper"}
+
+    def test_external_ref_is_left_intact(self, capsys):
+        spec = self._spec("other.yaml#/components/Pet")
+        assert self._schema(resolve_refs(spec)) == {"$ref": "other.yaml#/components/Pet"}
+        assert capsys.readouterr().err == ""

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -18,6 +18,23 @@ def _sdk_httpx():
     return getattr(_httpx_utils, "httpx2", None) or _httpx_utils.httpx
 
 
+def _token_endpoint_response(status_code, body=b""):
+    """A real response of the httpx flavour the installed SDK reads.
+
+    The SDK's refresh handling does more than look at ``status_code`` and
+    ``aread()``: its log line appends ``redirect_note(response)``, which
+    reaches for ``response.next_request``. A two-attribute stub therefore
+    raises AttributeError on every SDK carrying that diagnostic, so hand the
+    provider the type it actually expects.
+    """
+    httpx = _sdk_httpx()
+    return httpx.Response(
+        status_code,
+        content=body,
+        request=httpx.Request("POST", "https://example.com/oauth/token"),
+    )
+
+
 def _code_state(result):
     """Normalize a callback_handler result across SDK majors.
 
@@ -197,7 +214,15 @@ class TestFileTokenStorage:
 
 
 class TestRobustOAuthClientProvider:
-    """Behavior of the _RobustOAuthClientProvider subclass (issue #50)."""
+    """Behavior of the _RobustOAuthClientProvider subclass (issue #50).
+
+    These tests drive ``_initialize`` and ``_handle_refresh_response`` only, so
+    they build the provider with ``manual_callback=True``: the default flow
+    binds its loopback listener in ``build_oauth_provider`` and only closes it
+    once a callback is served, which leaks a bound port for the rest of the
+    session (and made these fixed ports collide once a failing test kept the
+    provider alive in its traceback).
+    """
 
     def test_initialize_restores_token_expiry_from_sidecar(self, tmp_path, monkeypatch):
         """A fresh process restoring tokens picks up the persisted expiry,
@@ -229,6 +254,7 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19881/callback",
+            manual_callback=True,
         )
 
         async def _drive():
@@ -265,6 +291,7 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19882/callback",
+            manual_callback=True,
         )
 
         async def _drive():
@@ -297,20 +324,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
-        # Build a synthetic failed refresh response
-        class _FakeResponse:
-            status_code = 400
-            async def aread(self):
-                return b'{"error":"invalid_grant"}'
+        # A definitive rejection from the token endpoint.
+        response = _token_endpoint_response(400, b'{"error":"invalid_grant"}')
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
             assert provider.context.client_info is not None
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             # In-memory and on-disk client_info both cleared
             assert provider.context.client_info is None
@@ -352,19 +377,17 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
         # A 503 from the token endpoint — transient, recoverable on retry.
-        class _FakeResponse:
-            status_code = 503
-            async def aread(self):
-                return b"<html>Service Unavailable</html>"
+        response = _token_endpoint_response(503, b"<html>Service Unavailable</html>")
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             # Persisted OAuth state survives so a later run can refresh again.
             assert provider.context.client_info is not None
@@ -395,18 +418,16 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19883/callback",
+            manual_callback=True,
         )
 
-        class _FakeResponse:
-            status_code = 401
-            async def aread(self):
-                return b""
+        response = _token_endpoint_response(401)
 
         async def _drive():
             await provider._initialize()
             provider.context.client_info = await storage.get_client_info()
 
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is False
             assert provider.context.client_info is None
             assert not storage._client_path.exists()
@@ -438,17 +459,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19884/callback",
+            manual_callback=True,
         )
 
         # Refresh response that rotates the access token but omits refresh_token
-        class _FakeResponse:
-            status_code = 200
-            async def aread(self):
-                return b'{"access_token":"new-access","token_type":"Bearer","expires_in":3600}'
+        response = _token_endpoint_response(
+            200,
+            b'{"access_token":"new-access","token_type":"Bearer","expires_in":3600}',
+        )
 
         async def _drive():
             await provider._initialize()
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is True
             # Old refresh token carried forward in memory …
             assert provider.context.current_tokens.access_token == "new-access"
@@ -483,19 +505,18 @@ class TestRobustOAuthClientProvider:
         provider = mcp2cli.build_oauth_provider(
             "https://example.com/mcp",
             redirect_uri="http://localhost:19885/callback",
+            manual_callback=True,
         )
 
-        class _FakeResponse:
-            status_code = 200
-            async def aread(self):
-                return (
-                    b'{"access_token":"new-access","token_type":"Bearer",'
-                    b'"refresh_token":"new-refresh","expires_in":3600}'
-                )
+        response = _token_endpoint_response(
+            200,
+            b'{"access_token":"new-access","token_type":"Bearer",'
+            b'"refresh_token":"new-refresh","expires_in":3600}',
+        )
 
         async def _drive():
             await provider._initialize()
-            ok = await provider._handle_refresh_response(_FakeResponse())
+            ok = await provider._handle_refresh_response(response)
             assert ok is True
             assert provider.context.current_tokens.refresh_token == "new-refresh"
 


### PR DESCRIPTION
Fixes #110

## Problem

Two gaps in `resolve_refs`, both hit by specs mcp2cli did not write:

1. **Dangling internal `$ref` → raw `KeyError` traceback.** The pointer walk did `target = target[p]` unguarded, so one broken reference anywhere in the document — even in an unused component — killed spec loading. The function already leaves circular refs and external refs unresolved; a dangling ref was the one shape that exploded instead.
2. **RFC 6901 escapes never decoded, arrays never indexable.** Legal pointers like `#/paths/~1users~1{id}/get/parameters/0` failed twice over: `~1`/`~0` looked up literally, and the numeric token raised `TypeError` against the list.

## Change

- `_json_pointer_unescape`: `~1` → `/` then `~0` → `~` (that order, or `~01` would wrongly become `/`).
- `_json_pointer_lookup`: walks dicts by key and lists by integer token, raising `LookupError` on any dangle — wrong key, bad index, or a pointer descending through a scalar.
- `resolve_refs` treats a dangle exactly like the existing cycle/external cases: the node stays unresolved, and a warning is printed **once per unique ref** on stderr so a spec with the same broken ref in fifty places doesn't print fifty lines.

Behaviour for well-formed specs is unchanged; the existing `TestResolveRefs` cases pass as-is.

## Tests

`tests/test_helpers.py::TestResolveRefsRobustness`, five cases:

- dangling ref does not raise, node left as-is, warning names the ref
- warning deduplicated across repeated occurrences
- `~1`/`~0` decoding resolves a ref through `a/b` and `c~d` keys
- numeric tokens index arrays (`#/shared/1`)
- a pointer descending through a scalar is left unresolved instead of raising

Verified on `main` (the two decode/array cases fail with `KeyError`/`TypeError` tracebacks; the dangling cases crash) and green with the change:

```
--- WITHOUT FIX ---
5 failed
--- WITH FIX ---
tests/test_helpers.py + tests/test_openapi.py: 138 passed
(2 pre-existing TestToonEncode failures on main are environment-dependent and unrelated)
```
