### PR TITLE
Forward the RFC 9207 `iss` parameter from the OAuth callback

### DIFF
--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -414,17 +414,20 @@ async def _list_tools_page(session, cursor: str | None):
     return await session.list_tools(params=params)
 
 
-def _authorization_code_result(code: str, state: str | None):
+def _authorization_code_result(code: str, state: str | None, iss: str | None = None):
     """Wrap a callback result in whatever ``callback_handler`` must return.
 
     v1 expects a plain ``(code, state)`` tuple; v2 expects an
-    ``AuthorizationCodeResult`` model.
+    ``AuthorizationCodeResult`` model. ``iss`` is the RFC 9207
+    authorization-response issuer: when the authorization server advertises it
+    in its metadata, the SDK validates the redirect's ``iss`` and fails the
+    flow if the value never reaches it.
     """
     try:
         from mcp.shared.auth import AuthorizationCodeResult
     except ImportError:
         return (code, state)
-    return AuthorizationCodeResult(code=code, state=state)
+    return AuthorizationCodeResult(code=code, state=state, iss=iss)
 
 
 def _ensure_utf8_output() -> None:
@@ -849,6 +852,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         elif "code" in params:
             _CallbackHandler.auth_code = params["code"][0]
             _CallbackHandler.state = params.get("state", [None])[0]
+            _CallbackHandler.iss = params.get("iss", [None])[0]
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
@@ -875,17 +879,22 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-def _parse_oauth_callback_input(text: str) -> tuple[str, str]:
-    """Extract ``(code, state)`` from a pasted OAuth callback URL.
+def _parse_oauth_callback_input(text: str) -> tuple[str, str, str | None]:
+    """Extract ``(code, state, iss)`` from a pasted OAuth callback URL.
 
     Accepts the full redirect target the browser landed on
     (``http://127.0.0.1:1234/callback?code=...&state=...``) or just its query
     string. PKCE and CSRF verification stay in the MCP SDK -- we only hand it
-    the two values it asks for. The SDK compares ``state`` against the one it
+    the values it asks for. The SDK compares ``state`` against the one it
     generated with ``secrets.compare_digest`` and treats ``None`` as a
     mismatch, so a paste missing ``state`` is rejected here with a readable
     message instead of surfacing as an opaque
     ``State parameter mismatch: None != ...``.
+
+    ``iss`` is optional in the redirect but mandatory to forward: under
+    RFC 9207 the SDK validates it whenever the authorization server advertises
+    it, and dropping it fails the flow with "Authorization response missing
+    iss parameter advertised by the authorization server".
     """
     text = text.strip().strip("'\"")
     if not text:
@@ -905,10 +914,10 @@ def _parse_oauth_callback_input(text: str) -> tuple[str, str]:
             "That URL has no 'state' parameter. Paste the URL unmodified -- "
             "the MCP SDK verifies state to prevent CSRF and rejects a missing one."
         )
-    return params["code"][0], params["state"][0]
+    return params["code"][0], params["state"][0], params.get("iss", [None])[0]
 
 
-def _prompt_oauth_callback(attempts: int = 3) -> tuple[str, str]:
+def _prompt_oauth_callback(attempts: int = 3) -> tuple[str, str, str | None]:
     """Read the OAuth callback URL from stdin.
 
     For hosts with no reachable browser -- a VPS over SSH, a container.
@@ -1286,12 +1295,13 @@ def build_oauth_provider(
             )
 
         async def callback_handler():
-            code, state = await anyio.to_thread.run_sync(_prompt_oauth_callback)
-            return _authorization_code_result(code, state)
+            code, state, iss = await anyio.to_thread.run_sync(_prompt_oauth_callback)
+            return _authorization_code_result(code, state, iss)
     else:
         # Reset callback handler state
         _CallbackHandler.auth_code = None
         _CallbackHandler.state = None
+        _CallbackHandler.iss = None
         _CallbackHandler.error = None
         _CallbackHandler.done = threading.Event()
 
@@ -1324,7 +1334,9 @@ def build_oauth_provider(
             if not _CallbackHandler.auth_code:
                 raise RuntimeError("No authorization code received")
             return _authorization_code_result(
-                _CallbackHandler.auth_code, _CallbackHandler.state
+                _CallbackHandler.auth_code,
+                _CallbackHandler.state,
+                getattr(_CallbackHandler, "iss", None),
             )
 
     return _RobustOAuthClientProvider(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -29,6 +29,11 @@ def _code_state(result):
     return (result.code, result.state)
 
 
+def _result_iss(result):
+    """The RFC 9207 issuer a callback_handler forwarded, if the SDK carries it."""
+    return None if isinstance(result, tuple) else getattr(result, "iss", None)
+
+
 class TestResolveSecret:
     """Tests for resolve_secret helper."""
 
@@ -1006,29 +1011,39 @@ class TestParseOAuthCallbackInput:
     """Tests for parsing a pasted OAuth callback URL (issue #71)."""
 
     def test_full_url(self):
-        code, state = mcp2cli._parse_oauth_callback_input(
+        code, state, iss = mcp2cli._parse_oauth_callback_input(
             "http://127.0.0.1:5311/callback?code=abc123&state=xyz789"
         )
-        assert (code, state) == ("abc123", "xyz789")
+        assert (code, state, iss) == ("abc123", "xyz789", None)
 
     def test_query_string_only(self):
         """A user who copied only the query part still gets through."""
         assert mcp2cli._parse_oauth_callback_input("code=abc&state=xyz") == (
             "abc",
             "xyz",
+            None,
         )
 
     def test_strips_surrounding_whitespace_and_quotes(self):
-        code, state = mcp2cli._parse_oauth_callback_input(
+        code, state, _ = mcp2cli._parse_oauth_callback_input(
             '  "http://127.0.0.1:1/callback?code=a&state=b"\n'
         )
         assert (code, state) == ("a", "b")
 
     def test_percent_encoded_code_is_decoded(self):
-        code, _ = mcp2cli._parse_oauth_callback_input(
+        code, _, _ = mcp2cli._parse_oauth_callback_input(
             "http://127.0.0.1:1/callback?code=a%2Fb%3Dc&state=s"
         )
         assert code == "a/b=c"
+
+    def test_iss_is_extracted_and_decoded(self):
+        """RFC 9207: the SDK validates iss when the server advertises it, so a
+        dropped iss fails the flow with 'Authorization response missing iss'."""
+        code, state, iss = mcp2cli._parse_oauth_callback_input(
+            "http://127.0.0.1:1/callback?code=a&state=b"
+            "&iss=https%3A%2F%2Fclerk.example.com"
+        )
+        assert (code, state, iss) == ("a", "b", "https://clerk.example.com")
 
     def test_error_redirect_raises_with_description(self):
         with pytest.raises(RuntimeError, match=r"access_denied \(user said no\)"):
@@ -1059,7 +1074,7 @@ class TestPromptOAuthCallback:
         monkeypatch.setattr(
             sys, "stdin", io.StringIO("http://127.0.0.1:1/callback?code=c1&state=s1\n")
         )
-        assert mcp2cli._prompt_oauth_callback() == ("c1", "s1")
+        assert mcp2cli._prompt_oauth_callback() == ("c1", "s1", None)
         assert "Paste the full callback URL" in capsys.readouterr().err
 
     def test_reprompts_after_malformed_paste(self, monkeypatch, capsys):
@@ -1069,7 +1084,7 @@ class TestPromptOAuthCallback:
             "stdin",
             io.StringIO("not-a-url\nhttp://127.0.0.1:1/callback?code=c2&state=s2\n"),
         )
-        assert mcp2cli._prompt_oauth_callback() == ("c2", "s2")
+        assert mcp2cli._prompt_oauth_callback() == ("c2", "s2", None)
         assert "attempt(s) left" in capsys.readouterr().err
 
     def test_gives_up_after_exhausting_attempts(self, monkeypatch):
@@ -1139,6 +1154,29 @@ class TestManualCallbackProvider:
             sys, "stdin", io.StringIO("http://127.0.0.1:1/callback?code=zz&state=yy\n")
         )
         assert _code_state(anyio.run(provider.context.callback_handler)) == ("zz", "yy")
+
+    def test_manual_callback_handler_forwards_iss(self, tmp_path, monkeypatch):
+        """Servers that send iss (RFC 9207) fail the token exchange unless the
+        handler forwards it to the SDK."""
+        import anyio
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp", manual_callback=True
+        )
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                "http://127.0.0.1:1/callback?code=zz&state=yy"
+                "&iss=https%3A%2F%2Fissuer.example.com\n"
+            ),
+        )
+        result = anyio.run(provider.context.callback_handler)
+
+        assert _code_state(result) == ("zz", "yy")
+        if not isinstance(result, tuple):
+            assert _result_iss(result) == "https://issuer.example.com"
 
     def test_manual_redirect_handler_prints_url_and_skips_browser(
         self, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
## Problem

Authorization servers that advertise `authorization_response_iss_parameter_supported` include an `iss` parameter in the redirect, and the MCP SDK validates it (`validate_authorization_response_iss`). Both mcp2cli callback paths extracted only `code` and `state`, so `iss` never reached `AuthorizationCodeResult` and every such flow failed:

```
mcp.client.auth.exceptions.OAuthFlowError: Authorization response missing iss
parameter advertised by the authorization server
```

Reproduced against `https://mcp.context7.com/mcp/oauth` (Clerk) with `--oauth-manual-callback` on a headless host. The pasted callback URL did contain `iss=https%3A%2F%2Fclerk.context7.com`, but it was dropped during parsing, so the flow could never complete.

## Fix

- `_parse_oauth_callback_input` returns `(code, state, iss)`.
- `_prompt_oauth_callback` propagates the third value.
- `_CallbackHandler` records `iss` for the local-listener flow too, so it is not limited to the manual path.
- `_authorization_code_result` takes an optional `iss` and passes it to `AuthorizationCodeResult`.

`iss` remains optional, so servers that omit it behave exactly as before, and the SDK v1 tuple path is untouched.

## Tests

Existing callers updated for the three-tuple. New tests cover extraction and percent-decoding of `iss`, and that the manual callback handler forwards it to the SDK result.

`pytest tests/test_oauth.py` → 80 passed. Full suite: 413 passed, with two pre-existing `TestToonEncode` failures that also occur on an unmodified checkout (they need the `toon` CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)