### PR TITLE
Fix all open issue tracks and integrate reviewed PR contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,13 @@ mcp2cli bake create petstore --spec https://api.example.com/spec.json \
   --exclude "delete-*,update-*" --methods GET,POST --cache-ttl 7200
 
 # Create a baked tool from an MCP stdio server
-mcp2cli bake create mygit --mcp-stdio "npx @mcp/github" \
-  --include "search-*,list-*" --exclude "delete-*"
+mcp2cli bake create myfs --mcp-stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" \
+  --include "search-*,list-*" --exclude "list-allowed-*"
 
 # Use a baked tool with @ prefix — no connection flags needed
 mcp2cli @petstore --list
 mcp2cli @petstore list-pets --limit 10
-mcp2cli @mygit search-repos --query "rust"
+mcp2cli @myfs search-files --path /tmp --pattern "*.md"
 
 # Manage baked tools
 mcp2cli bake list                         # show all baked tools

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Filtering options:
 
 Configs are stored in `~/.config/mcp2cli/baked.json`. Override with `MCP2CLI_CONFIG_DIR`.
 
+`bake show` masks the credential values it knows about — the OAuth client secret and every `--auth-header` value — while leaving `env:`/`file:` references readable so the config stays diagnosable. Values baked in with `--env` are printed as stored, so scrub those before pasting the output if an env var carries a token.
+
 ### Usage-aware tool ranking
 
 mcp2cli tracks tool invocations locally and uses that data to rank `--list` output, reducing token costs for LLM agents working with large servers.

--- a/skills/mcp2cli/SKILL.md
+++ b/skills/mcp2cli/SKILL.md
@@ -257,8 +257,8 @@ Save connection settings as named configurations to avoid repeating flags:
 mcp2cli bake create petstore --spec https://api.example.com/spec.json \
   --exclude "delete-*,update-*" --methods GET,POST --cache-ttl 7200
 
-mcp2cli bake create mygit --mcp-stdio "npx @mcp/github" \
-  --include "search-*,list-*" --exclude "delete-*"
+mcp2cli bake create myfs --mcp-stdio "npx -y @modelcontextprotocol/server-filesystem /tmp" \
+  --include "search-*,list-*" --exclude "list-allowed-*"
 
 # Use with @ prefix
 mcp2cli @petstore --list

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1341,8 +1341,36 @@ def build_oauth_provider(
 # ---------------------------------------------------------------------------
 
 
+def _json_pointer_unescape(token: str) -> str:
+    """Decode RFC 6901 escapes: ``~1`` is ``/`` and ``~0`` is ``~``.
+
+    Order matters -- ``~1`` first, or ``~01`` would wrongly become ``/``.
+    """
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _json_pointer_lookup(root, pointer_tokens: list[str]):
+    """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
+    target = root
+    for raw in pointer_tokens:
+        token = _json_pointer_unescape(raw)
+        if isinstance(target, dict):
+            if token not in target:
+                raise LookupError(token)
+            target = target[token]
+        elif isinstance(target, list):
+            try:
+                target = target[int(token)]
+            except (ValueError, IndexError):
+                raise LookupError(token) from None
+        else:
+            raise LookupError(token)
+    return target
+
+
 def resolve_refs(spec: dict) -> dict:
     spec = copy.deepcopy(spec)
+    warned: set[str] = set()
 
     def _resolve(node, root, seen):
         if isinstance(node, dict):
@@ -1352,10 +1380,21 @@ def resolve_refs(spec: dict) -> dict:
                     return node
                 seen = seen | {ref}
                 if ref.startswith("#/"):
-                    parts = ref[2:].split("/")
-                    target = root
-                    for p in parts:
-                        target = target[p]
+                    try:
+                        target = _json_pointer_lookup(root, ref[2:].split("/"))
+                    except LookupError:
+                        # A dangling reference in a spec we did not write must
+                        # not take down the CLI. Leave the node unresolved --
+                        # the same shape external refs and cycles already
+                        # produce -- and say so once.
+                        if ref not in warned:
+                            warned.add(ref)
+                            print(
+                                f"Warning: unresolvable $ref {ref!r} in spec; "
+                                "leaving it unresolved.",
+                                file=sys.stderr,
+                            )
+                        return node
                     return _resolve(copy.deepcopy(target), root, seen)
                 return node
             return {k: _resolve(v, root, seen) for k, v in node.items()}

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2733,7 +2733,11 @@ def _collect_openapi_params(
                     if val is not None:
                         extra_headers[p.original_name] = str(val)
                     continue
-                if p.location == "path":
+                if p.location in ("path", "query", "cookie"):
+                    # Path and query values travel in the URL, and a cookie
+                    # parameter is not a body field either. None of them
+                    # belong in the JSON payload. Query values are collected
+                    # separately below.
                     continue
                 if p.location == "file":
                     if val is not None:

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1424,32 +1424,75 @@ def load_openapi_spec(
 # ---------------------------------------------------------------------------
 
 
+_OPENAPI_METHODS = ("get", "post", "put", "delete", "patch")
+
+
+def _openapi_operation_name(path: str, method: str, details: dict) -> str:
+    """The natural CLI name for an operation, before collision handling."""
+    op_id = details.get("operationId")
+    if op_id:
+        return to_kebab(op_id)
+    slug = path.strip("/").replace("/", "-").replace("{", "").replace("}", "")
+    return f"{method}-{slug}" if slug else method
+
+
+def _openapi_natural_names(spec: dict) -> set[str]:
+    """Every operation's natural name, so an alias can never shadow one."""
+    names: set[str] = set()
+    for path, methods in spec.get("paths", {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, details in methods.items():
+            if method not in _OPENAPI_METHODS or not isinstance(details, dict):
+                continue
+            names.add(_openapi_operation_name(path, method, details))
+    return names
+
+
+def _unique_openapi_name(
+    name: str, method: str, reserved: set[str], used: set[str]
+) -> str:
+    """Return a free CLI name for an operation.
+
+    The first operation to claim a name keeps it. A later collision is
+    disambiguated by the HTTP method, and then by a numeric suffix if that is
+    taken too. A generated alias is never allowed to equal another
+    operation's natural name, which would make that operation unreachable.
+    """
+    if name not in used:
+        return name
+    candidate = f"{name}-{method}"
+    if candidate not in reserved and candidate not in used:
+        return candidate
+    suffix = 2
+    while True:
+        numbered = f"{candidate}-{suffix}"
+        if numbered not in reserved and numbered not in used:
+            return numbered
+        suffix += 1
+
+
 def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     commands: list[CommandDef] = []
-    seen_names: dict[str, int] = {}
+    natural_names = _openapi_natural_names(spec)
+    used_names: set[str] = set()
 
     for path, methods in spec.get("paths", {}).items():
         if not isinstance(methods, dict):
             continue
         for method, details in methods.items():
-            if method not in ("get", "post", "put", "delete", "patch"):
+            if method not in _OPENAPI_METHODS:
                 continue
             if not isinstance(details, dict):
                 continue
 
-            op_id = details.get("operationId")
-            if op_id:
-                name = to_kebab(op_id)
-            else:
-                slug = (
-                    path.strip("/").replace("/", "-").replace("{", "").replace("}", "")
-                )
-                name = f"{method}-{slug}" if slug else method
-
-            if name in seen_names:
-                seen_names[name] += 1
-                name = f"{name}-{method}"
-            seen_names[name] = 1
+            name = _unique_openapi_name(
+                _openapi_operation_name(path, method, details),
+                method,
+                natural_names,
+                used_names,
+            )
+            used_names.add(name)
 
             desc = (
                 details.get("summary")

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1883,6 +1883,29 @@ def _build_graphql_param(arg: dict, types_by_name: dict) -> ParamDef:
     )
 
 
+def _unique_graphql_name(
+    name: str, op_type: str, reserved: set[str], used: set[str]
+) -> str:
+    """Return a free CLI name for a GraphQL field.
+
+    The first field to claim a name keeps it. A later collision is
+    disambiguated by the operation type, then by a numeric suffix if that is
+    taken too. A generated alias is never allowed to equal another field's
+    own name, which would make that field unreachable.
+    """
+    if name not in used:
+        return name
+    candidate = f"{op_type}-{name}"
+    if candidate not in reserved and candidate not in used:
+        return candidate
+    suffix = 2
+    while True:
+        numbered = f"{candidate}-{suffix}"
+        if numbered not in reserved and numbered not in used:
+            return numbered
+        suffix += 1
+
+
 def extract_graphql_commands(schema: dict) -> list[CommandDef]:
     """Convert introspection schema into CommandDef list."""
     types_by_name = {t["name"]: t for t in schema.get("types", []) if t.get("name")}
@@ -1891,46 +1914,52 @@ def extract_graphql_commands(schema: dict) -> list[CommandDef]:
     mutation_type_name = (schema.get("mutationType") or {}).get("name")
 
     commands: list[CommandDef] = []
-    seen_names: set[str] = set()
 
     query_fields = types_by_name.get(query_type_name, {}).get("fields", []) if query_type_name else []
     mutation_fields = types_by_name.get(mutation_type_name, {}).get("fields", []) if mutation_type_name else []
     collisions = _detect_field_collisions(query_fields, mutation_fields)
 
-    for op_type, type_name, fields in [
-        ("query", query_type_name, query_fields),
-        ("mutation", mutation_type_name, mutation_fields),
-    ]:
+    # Pass 1: every field's natural CLI name. A field whose *wire* name exists
+    # under both Query and Mutation is prefixed with its operation type on both
+    # sides, which is the pre-existing symmetric naming and is kept as-is.
+    entries: list[tuple[str, str, dict]] = []
+    for op_type, fields in (("query", query_fields), ("mutation", mutation_fields)):
         for field_def in fields:
             field_name = field_def["name"]
             if field_name.startswith("__"):
                 continue
-
-            cli_name = to_kebab(field_name)
+            base = to_kebab(field_name)
             if field_name in collisions:
-                cli_name = f"{op_type}-{cli_name}"
+                base = f"{op_type}-{base}"
+            entries.append((base, op_type, field_def))
 
-            if cli_name in seen_names:
-                cli_name = f"{op_type}-{cli_name}"
-            seen_names.add(cli_name)
+    # Pass 2: allocate against the complete set of natural names, so a
+    # generated alias can never shadow a field that owns that name.
+    reserved = {base for base, _, _ in entries}
+    used: set[str] = set()
 
-            desc = field_def.get("description") or f"{op_type} {field_name}"
-            params = [
-                _build_graphql_param(arg, types_by_name)
-                for arg in field_def.get("args", [])
-            ]
+    for base, op_type, field_def in entries:
+        field_name = field_def["name"]
+        cli_name = _unique_graphql_name(base, op_type, reserved, used)
+        used.add(cli_name)
 
-            commands.append(
-                CommandDef(
-                    name=cli_name,
-                    description=desc,
-                    params=params,
-                    has_body=bool(params),
-                    graphql_operation_type=op_type,
-                    graphql_field_name=field_name,
-                    graphql_return_type=field_def.get("type"),
-                )
+        desc = field_def.get("description") or f"{op_type} {field_name}"
+        params = [
+            _build_graphql_param(arg, types_by_name)
+            for arg in field_def.get("args", [])
+        ]
+
+        commands.append(
+            CommandDef(
+                name=cli_name,
+                description=desc,
+                params=params,
+                has_body=bool(params),
+                graphql_operation_type=op_type,
+                graphql_field_name=field_name,
+                graphql_return_type=field_def.get("type"),
             )
+        )
 
     return commands
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -3507,17 +3507,27 @@ def session_start(
     )
 
     log_path = _session_log_path(name)
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            "-c",
-            f"import mcp2cli; mcp2cli._run_session_daemon({json.dumps(daemon_script)})",
-        ],
-        start_new_session=True,
-        stdout=subprocess.DEVNULL,
-        stderr=open(log_path, "a"),
-        stdin=subprocess.DEVNULL,
-    )
+    # Route both streams to the session log rather than /dev/null: sandboxes
+    # that deny opening /dev/null (agent runners, hardened containers) would
+    # otherwise fail the spawn with PermissionError before the daemon starts.
+    # stdin is a closed pipe for the same reason -- the daemon never reads it.
+    log_file = open(log_path, "a")
+    try:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                f"import mcp2cli; mcp2cli._run_session_daemon({json.dumps(daemon_script)})",
+            ],
+            start_new_session=True,
+            stdout=log_file,
+            stderr=log_file,
+            stdin=subprocess.PIPE,
+        )
+    finally:
+        log_file.close()
+    if proc.stdin is not None:
+        proc.stdin.close()
 
     # Wait for socket to appear
     sock_path = _session_sock_path(name)

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1424,6 +1424,29 @@ def load_openapi_spec(
 # ---------------------------------------------------------------------------
 
 
+def _merge_openapi_parameters(path_level, operation_level) -> list[dict]:
+    """Combine path-item parameters with an operation's own.
+
+    OpenAPI 3.x declares that ``parameters`` on a path item apply to every
+    operation under that path. An operation may *override* an inherited
+    parameter by redeclaring the same ``name``/``in`` pair, but it cannot
+    remove one. Operation-level entries therefore win on collision, and the
+    inherited ones are kept otherwise.
+
+    Malformed entries (non-dicts, or missing ``name``) are skipped rather
+    than raising: a spec we did not write should not crash the CLI.
+    """
+    merged: dict[tuple[str, str], dict] = {}
+    for group in (path_level, operation_level):
+        if not isinstance(group, list):
+            continue
+        for param in group:
+            if not isinstance(param, dict) or "name" not in param:
+                continue
+            merged[(param["name"], param.get("in", "query"))] = param
+    return list(merged.values())
+
+
 def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     commands: list[CommandDef] = []
     seen_names: dict[str, int] = {}
@@ -1431,6 +1454,8 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
     for path, methods in spec.get("paths", {}).items():
         if not isinstance(methods, dict):
             continue
+        # Applies to every operation under this path (OpenAPI 3.x).
+        shared_params = methods.get("parameters")
         for method, details in methods.items():
             if method not in ("get", "post", "put", "delete", "patch"):
                 continue
@@ -1458,8 +1483,11 @@ def extract_openapi_commands(spec: dict) -> list[CommandDef]:
             )
             params: list[ParamDef] = []
 
-            # Parameters (path, query, header)
-            for param in details.get("parameters", []):
+            # Parameters (path, query, header) -- inherited from the
+            # path item, then overridden by the operation's own.
+            for param in _merge_openapi_parameters(
+                shared_params, details.get("parameters")
+            ):
                 schema = param.get("schema", {})
                 py_type, suffix = schema_type_to_python(schema)
                 p = ParamDef(

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -414,17 +414,20 @@ async def _list_tools_page(session, cursor: str | None):
     return await session.list_tools(params=params)
 
 
-def _authorization_code_result(code: str, state: str | None):
+def _authorization_code_result(code: str, state: str | None, iss: str | None = None):
     """Wrap a callback result in whatever ``callback_handler`` must return.
 
     v1 expects a plain ``(code, state)`` tuple; v2 expects an
-    ``AuthorizationCodeResult`` model.
+    ``AuthorizationCodeResult`` model. ``iss`` is the RFC 9207
+    authorization-response issuer: when the authorization server advertises it
+    in its metadata, the SDK validates the redirect's ``iss`` and fails the
+    flow if the value never reaches it.
     """
     try:
         from mcp.shared.auth import AuthorizationCodeResult
     except ImportError:
         return (code, state)
-    return AuthorizationCodeResult(code=code, state=state)
+    return AuthorizationCodeResult(code=code, state=state, iss=iss)
 
 
 def _ensure_utf8_output() -> None:
@@ -849,6 +852,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         elif "code" in params:
             _CallbackHandler.auth_code = params["code"][0]
             _CallbackHandler.state = params.get("state", [None])[0]
+            _CallbackHandler.iss = params.get("iss", [None])[0]
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
@@ -875,17 +879,22 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-def _parse_oauth_callback_input(text: str) -> tuple[str, str]:
-    """Extract ``(code, state)`` from a pasted OAuth callback URL.
+def _parse_oauth_callback_input(text: str) -> tuple[str, str, str | None]:
+    """Extract ``(code, state, iss)`` from a pasted OAuth callback URL.
 
     Accepts the full redirect target the browser landed on
     (``http://127.0.0.1:1234/callback?code=...&state=...``) or just its query
     string. PKCE and CSRF verification stay in the MCP SDK -- we only hand it
-    the two values it asks for. The SDK compares ``state`` against the one it
+    the values it asks for. The SDK compares ``state`` against the one it
     generated with ``secrets.compare_digest`` and treats ``None`` as a
     mismatch, so a paste missing ``state`` is rejected here with a readable
     message instead of surfacing as an opaque
     ``State parameter mismatch: None != ...``.
+
+    ``iss`` is optional in the redirect but mandatory to forward: under
+    RFC 9207 the SDK validates it whenever the authorization server advertises
+    it, and dropping it fails the flow with "Authorization response missing
+    iss parameter advertised by the authorization server".
     """
     text = text.strip().strip("'\"")
     if not text:
@@ -905,10 +914,10 @@ def _parse_oauth_callback_input(text: str) -> tuple[str, str]:
             "That URL has no 'state' parameter. Paste the URL unmodified -- "
             "the MCP SDK verifies state to prevent CSRF and rejects a missing one."
         )
-    return params["code"][0], params["state"][0]
+    return params["code"][0], params["state"][0], params.get("iss", [None])[0]
 
 
-def _prompt_oauth_callback(attempts: int = 3) -> tuple[str, str]:
+def _prompt_oauth_callback(attempts: int = 3) -> tuple[str, str, str | None]:
     """Read the OAuth callback URL from stdin.
 
     For hosts with no reachable browser -- a VPS over SSH, a container.
@@ -1286,12 +1295,13 @@ def build_oauth_provider(
             )
 
         async def callback_handler():
-            code, state = await anyio.to_thread.run_sync(_prompt_oauth_callback)
-            return _authorization_code_result(code, state)
+            code, state, iss = await anyio.to_thread.run_sync(_prompt_oauth_callback)
+            return _authorization_code_result(code, state, iss)
     else:
         # Reset callback handler state
         _CallbackHandler.auth_code = None
         _CallbackHandler.state = None
+        _CallbackHandler.iss = None
         _CallbackHandler.error = None
         _CallbackHandler.done = threading.Event()
 
@@ -1324,7 +1334,9 @@ def build_oauth_provider(
             if not _CallbackHandler.auth_code:
                 raise RuntimeError("No authorization code received")
             return _authorization_code_result(
-                _CallbackHandler.auth_code, _CallbackHandler.state
+                _CallbackHandler.auth_code,
+                _CallbackHandler.state,
+                getattr(_CallbackHandler, "iss", None),
             )
 
     return _RobustOAuthClientProvider(

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from importlib.metadata import version as _pkg_version
 
-__version__ = _pkg_version("mcp2cli")
+try:
+    __version__ = _pkg_version("mcp2cli")
+except Exception:
+    __version__ = "0.0.0-dev"
 
 import argparse
 import copy
@@ -2881,6 +2884,8 @@ def _run_mcp_clean(fn, source: str):
                 " — the server rejected the request; pass credentials with "
                 "--auth-header 'Name:Value' or use the --oauth-* options"
             )
+        elif any(phrase in lowered for phrase in ["endofstream", "brokenpipeerror", "connection closed", "disconnect"]):
+            hint = " — the server disconnected unexpectedly. It may have crashed or terminated."
         else:
             hint = ""
         print(f"Error: cannot use MCP server at {source}: {message}{hint}", file=sys.stderr)

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -632,18 +632,48 @@ def cache_key_for(config: dict) -> str:
     ).hexdigest()[:16]
 
 def load_cached(key: str, ttl: int) -> dict | None:
+    """Read a cache entry, or None when it is missing, stale or unusable.
+
+    A corrupt entry is treated as a miss rather than an error. The cache is
+    an optimisation, so a bad file should cost one refetch -- not every
+    later invocation, until someone works out which file to delete by hand.
+    This matches _load_usage() and _load_baked_all(), which already tolerate
+    exactly this.
+    """
     path = CACHE_DIR / f"{key}.json"
     if not path.exists():
         return None
-    age = time.time() - path.stat().st_mtime
-    if age >= ttl:
+    try:
+        age = time.time() - path.stat().st_mtime
+        if age >= ttl:
+            return None
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return None
-    return json.loads(path.read_text())
 
 
 def save_cache(key: str, data: dict):
+    """Write a cache entry atomically.
+
+    A plain write_text() is not atomic: an interrupt, a full disk or two
+    concurrent mcp2cli runs can leave a half-written file behind, which is
+    how a cache entry becomes corrupt in the first place. Serialise first,
+    write to a private temp file in the same directory, then os.replace()
+    it into place -- readers only ever observe the old file or the new one.
+    """
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    (CACHE_DIR / f"{key}.json").write_text(json.dumps(data))
+    path = CACHE_DIR / f"{key}.json"
+    payload = json.dumps(data)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(payload)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2428,6 +2428,45 @@ def _bake_show(argv: list[str]) -> None:
     print(json.dumps(display, indent=2, ensure_ascii=False))
 
 
+_WRAPPER_MARKER = "# installed by mcp2cli bake install"
+
+
+def _wrapper_is_ours(path: Path) -> bool:
+    """True only for a wrapper script mcp2cli itself wrote."""
+    try:
+        return _WRAPPER_MARKER in path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _remove_installed_wrapper(name: str, cfg: dict) -> None:
+    """Delete the wrapper for *name*, but only if mcp2cli installed it.
+
+    `bake install` records its destination in the config, so a wrapper
+    placed by --dir is found too. Anything we cannot positively identify as
+    ours is left alone and reported: deleting an unrelated executable that
+    merely shares the baked tool's name is far worse than leaving a stale
+    wrapper behind.
+    """
+    recorded = cfg.get("wrapper_path")
+    wrapper = Path(recorded) if recorded else Path.home() / ".local" / "bin" / name
+    if not wrapper.exists():
+        return
+    if not _wrapper_is_ours(wrapper):
+        print(
+            f"Note: left {wrapper} in place -- it was not installed by "
+            f"mcp2cli bake install.",
+            file=sys.stderr,
+        )
+        return
+    try:
+        wrapper.unlink()
+    except OSError as exc:
+        print(f"Warning: could not remove {wrapper}: {exc}", file=sys.stderr)
+        return
+    print(f"Removed installed wrapper: {wrapper}")
+
+
 def _bake_remove(argv: list[str]) -> None:
     p = argparse.ArgumentParser(prog="mcp2cli bake remove")
     p.add_argument("name")
@@ -2436,13 +2475,10 @@ def _bake_remove(argv: list[str]) -> None:
     if args.name not in all_configs:
         print(f"Error: no baked tool named '{args.name}'", file=sys.stderr)
         sys.exit(1)
+    cfg = all_configs[args.name]
     del all_configs[args.name]
     _save_baked_all(all_configs)
-    # Clean up any installed wrapper
-    wrapper = Path.home() / ".local" / "bin" / args.name
-    if wrapper.exists():
-        wrapper.unlink()
-        print(f"Removed installed wrapper: {wrapper}")
+    _remove_installed_wrapper(args.name, cfg)
     print(f"Baked tool '{args.name}' removed.")
 
 
@@ -2495,9 +2531,16 @@ def _bake_install(argv: list[str]) -> None:
     # Resolve mcp2cli path
     mcp2cli_bin = shutil.which("mcp2cli") or "mcp2cli"
     wrapper.write_text(
-        f"#!/bin/sh\nexec {shlex.quote(mcp2cli_bin)} @{args.name} \"$@\"\n"
+        f"#!/bin/sh\n{_WRAPPER_MARKER}\n"
+        f"exec {shlex.quote(mcp2cli_bin)} @{args.name} \"$@\"\n"
     )
     wrapper.chmod(0o755)
+    # Remember where it landed so `bake remove` can find it again, including
+    # when --dir put it somewhere other than ~/.local/bin.
+    all_configs = _load_baked_all()
+    if args.name in all_configs:
+        all_configs[args.name]["wrapper_path"] = str(wrapper)
+        _save_baked_all(all_configs)
     print(f"Installed wrapper: {wrapper}")
     if args.dir is None and str(bin_dir) not in os.environ.get("PATH", ""):
         print(f"  Note: {bin_dir} may not be in your PATH")

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -2407,6 +2407,21 @@ def _bake_list() -> None:
         print(f"{name:<20} {st:<10} {src:<50}")
 
 
+def _mask_secret(value: str) -> str:
+    """Mask a secret for display.
+
+    ``env:`` and ``file:`` values are references, not secrets, and stay
+    readable so the config remains diagnosable.
+    """
+    if value.startswith("env:") or value.startswith("file:"):
+        return value
+    return value[:4] + "****" if len(value) > 4 else "****"
+
+
+# Baked-config fields whose values must never be printed in the clear.
+_SECRET_BAKE_FIELDS = ("oauth_client_secret",)
+
+
 def _bake_show(argv: list[str]) -> None:
     p = argparse.ArgumentParser(prog="mcp2cli bake show")
     p.add_argument("name")
@@ -2415,16 +2430,17 @@ def _bake_show(argv: list[str]) -> None:
     if cfg is None:
         print(f"Error: no baked tool named '{args.name}'", file=sys.stderr)
         sys.exit(1)
-    # Mask secrets in auth headers for display
+    # Mask secrets for display: auth header values and any secret-bearing
+    # top-level field (the README promises `bake show` output is safe to
+    # share).
     display = dict(cfg)
     if display.get("auth_headers"):
-        masked = []
-        for name, val in display["auth_headers"]:
-            if val.startswith("env:") or val.startswith("file:"):
-                masked.append([name, val])
-            else:
-                masked.append([name, val[:4] + "****" if len(val) > 4 else "****"])
-        display["auth_headers"] = masked
+        display["auth_headers"] = [
+            [name, _mask_secret(val)] for name, val in display["auth_headers"]
+        ]
+    for field in _SECRET_BAKE_FIELDS:
+        if display.get(field):
+            display[field] = _mask_secret(display[field])
     print(json.dumps(display, indent=2, ensure_ascii=False))
 
 

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -27,7 +27,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from datetime import datetime, timezone
 
@@ -1349,22 +1349,61 @@ def _json_pointer_unescape(token: str) -> str:
     return token.replace("~1", "/").replace("~0", "~")
 
 
+def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
+    """Candidate decodings of one reference token, most literal first.
+
+    A ``$ref`` is a URI, so RFC 6901 section 6 percent-encodes the pointer it
+    carries in the fragment: a legal reference to a schema named ``Pet Dog``
+    arrives as ``Pet%20Dog``, and a path item ``/pets/{id}`` as
+    ``~1pets~1%7Bid%7D``. Percent-decoding runs first, since it was applied
+    over the ``~`` escaping. Plenty of hand-written specs skip the encoding
+    step, so the literal token is tried before the decoded one -- a component
+    genuinely named ``Pet%20Dog`` still resolves, and specs that encoded
+    nothing behave exactly as they did before.
+    """
+    literal = _json_pointer_unescape(raw)
+    decoded = _json_pointer_unescape(unquote(raw))
+    return (literal,) if decoded == literal else (literal, decoded)
+
+
+# RFC 6901: an array index is "0", or a digit string with no leading zero.
+# ``int()`` is far more generous -- it accepts "-1" (which would silently
+# select the *last* element), "+1", "01", " 1 ", "1_0" and Unicode digits --
+# so a token is screened before conversion.
+_ARRAY_INDEX_RE = re.compile(r"0|[1-9][0-9]*")
+# No list holds 10**19 items, so a longer digit run is out of range by
+# inspection. Checking the length first also keeps a pathological token away
+# from int(), whose behaviour on huge digit strings hangs on CPython's
+# integer-string conversion limit rather than on anything we control.
+_ARRAY_INDEX_MAX_DIGITS = 19
+
+
+def _array_index(token: str, length: int) -> int | None:
+    """Index *token* addresses in a list of *length*, or None if it does not."""
+    if len(token) > _ARRAY_INDEX_MAX_DIGITS or not _ARRAY_INDEX_RE.fullmatch(token):
+        return None
+    index = int(token)
+    return index if index < length else None
+
+
 def _json_pointer_lookup(root, pointer_tokens: list[str]):
     """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
     target = root
     for raw in pointer_tokens:
-        token = _json_pointer_unescape(raw)
-        if isinstance(target, dict):
-            if token not in target:
-                raise LookupError(token)
-            target = target[token]
-        elif isinstance(target, list):
-            try:
-                target = target[int(token)]
-            except (ValueError, IndexError):
-                raise LookupError(token) from None
+        for token in _json_pointer_tokens(raw):
+            if isinstance(target, dict):
+                if token in target:
+                    target = target[token]
+                    break
+            elif isinstance(target, list):
+                index = _array_index(token, len(target))
+                if index is not None:
+                    target = target[index]
+                    break
+            else:
+                raise LookupError(raw)
         else:
-            raise LookupError(token)
+            raise LookupError(raw)
     return target
 
 
@@ -1389,8 +1428,12 @@ def resolve_refs(spec: dict) -> dict:
                         # produce -- and say so once.
                         if ref not in warned:
                             warned.add(ref)
+                            # A ref is spec-controlled and can be arbitrarily
+                            # long, so keep the diagnostic to one readable
+                            # line instead of echoing the whole token.
+                            shown = ref if len(ref) <= 200 else ref[:200] + "..."
                             print(
-                                f"Warning: unresolvable $ref {ref!r} in spec; "
+                                f"Warning: unresolvable $ref {shown!r} in spec; "
                                 "leaving it unresolved.",
                                 file=sys.stderr,
                             )

--- a/src/mcp2cli/__init__.py
+++ b/src/mcp2cli/__init__.py
@@ -1349,21 +1349,17 @@ def _json_pointer_unescape(token: str) -> str:
     return token.replace("~1", "/").replace("~0", "~")
 
 
-def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
-    """Candidate decodings of one reference token, most literal first.
+def _json_pointer_tokens(fragment: str) -> list[str]:
+    """Split a URI fragment into decoded JSON Pointer reference tokens.
 
     A ``$ref`` is a URI, so RFC 6901 section 6 percent-encodes the pointer it
-    carries in the fragment: a legal reference to a schema named ``Pet Dog``
-    arrives as ``Pet%20Dog``, and a path item ``/pets/{id}`` as
-    ``~1pets~1%7Bid%7D``. Percent-decoding runs first, since it was applied
-    over the ``~`` escaping. Plenty of hand-written specs skip the encoding
-    step, so the literal token is tried before the decoded one -- a component
-    genuinely named ``Pet%20Dog`` still resolves, and specs that encoded
-    nothing behave exactly as they did before.
+    carries in the fragment. Decoding therefore unwinds the two layers in the
+    order they were applied: percent-decode the whole fragment first, then
+    split on the ``/`` separators it now spells out, then decode the ``~``
+    escapes the encoding was applied over. A member name holding a ``/`` is
+    ``~1`` (or ``%7E1``), a ``~`` is ``~0``, and a literal ``%`` is ``%25``.
     """
-    literal = _json_pointer_unescape(raw)
-    decoded = _json_pointer_unescape(unquote(raw))
-    return (literal,) if decoded == literal else (literal, decoded)
+    return [_json_pointer_unescape(t) for t in unquote(fragment).split("/")]
 
 
 # RFC 6901: an array index is "0", or a digit string with no leading zero.
@@ -1371,39 +1367,38 @@ def _json_pointer_tokens(raw: str) -> tuple[str, ...]:
 # select the *last* element), "+1", "01", " 1 ", "1_0" and Unicode digits --
 # so a token is screened before conversion.
 _ARRAY_INDEX_RE = re.compile(r"0|[1-9][0-9]*")
-# No list holds 10**19 items, so a longer digit run is out of range by
-# inspection. Checking the length first also keeps a pathological token away
-# from int(), whose behaviour on huge digit strings hangs on CPython's
-# integer-string conversion limit rather than on anything we control.
-_ARRAY_INDEX_MAX_DIGITS = 19
 
 
 def _array_index(token: str, length: int) -> int | None:
     """Index *token* addresses in a list of *length*, or None if it does not."""
-    if len(token) > _ARRAY_INDEX_MAX_DIGITS or not _ARRAY_INDEX_RE.fullmatch(token):
+    if not length or not _ARRAY_INDEX_RE.fullmatch(token):
         return None
-    index = int(token)
-    return index if index < length else None
+    # Both strings are canonical decimals, so (width, lexicographic) orders
+    # them numerically. Comparing them before converting keeps a spec from
+    # handing int() an arbitrarily long digit run, where CPython's
+    # integer-string conversion limit -- which a host may raise or disable --
+    # would decide what happens instead of us.
+    largest = str(length - 1)
+    if (len(token), token) > (len(largest), largest):
+        return None
+    return int(token)
 
 
-def _json_pointer_lookup(root, pointer_tokens: list[str]):
-    """Walk *root* by JSON Pointer tokens. Raises LookupError when it dangles."""
+def _json_pointer_lookup(root, tokens: list[str]):
+    """Walk *root* by decoded pointer tokens. Raises LookupError on a dangle."""
     target = root
-    for raw in pointer_tokens:
-        for token in _json_pointer_tokens(raw):
-            if isinstance(target, dict):
-                if token in target:
-                    target = target[token]
-                    break
-            elif isinstance(target, list):
-                index = _array_index(token, len(target))
-                if index is not None:
-                    target = target[index]
-                    break
-            else:
-                raise LookupError(raw)
+    for token in tokens:
+        if isinstance(target, dict):
+            if token not in target:
+                raise LookupError(token)
+            target = target[token]
+        elif isinstance(target, list):
+            index = _array_index(token, len(target))
+            if index is None:
+                raise LookupError(token)
+            target = target[index]
         else:
-            raise LookupError(raw)
+            raise LookupError(token)
     return target
 
 
@@ -1420,7 +1415,9 @@ def resolve_refs(spec: dict) -> dict:
                 seen = seen | {ref}
                 if ref.startswith("#/"):
                     try:
-                        target = _json_pointer_lookup(root, ref[2:].split("/"))
+                        target = _json_pointer_lookup(
+                            root, _json_pointer_tokens(ref[2:])
+                        )
                     except LookupError:
                         # A dangling reference in a spec we did not write must
                         # not take down the CLI. Leave the node unresolved --
@@ -1428,12 +1425,8 @@ def resolve_refs(spec: dict) -> dict:
                         # produce -- and say so once.
                         if ref not in warned:
                             warned.add(ref)
-                            # A ref is spec-controlled and can be arbitrarily
-                            # long, so keep the diagnostic to one readable
-                            # line instead of echoing the whole token.
-                            shown = ref if len(ref) <= 200 else ref[:200] + "..."
                             print(
-                                f"Warning: unresolvable $ref {shown!r} in spec; "
+                                f"Warning: unresolvable $ref {ref!r} in spec; "
                                 "leaving it unresolved.",
                                 file=sys.stderr,
                             )

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -549,3 +549,110 @@ class TestBakeInstall:
         )
         assert r.returncode == 0
         assert "may not be in your PATH" not in r.stdout
+
+
+class TestBakeRemoveWrapperSafety:
+    """`bake remove` must only delete wrappers mcp2cli itself installed."""
+
+    def _baked(self, monkeypatch, tmp_path, name, extra=None):
+        import mcp2cli
+        cfg_dir = tmp_path / "config"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(mcp2cli, "CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(mcp2cli, "BAKED_FILE", cfg_dir / "baked.json")
+        config = {"source_type": "mcp", "source": "https://example.com/mcp"}
+        config.update(extra or {})
+        mcp2cli._save_baked_all({name: config})
+        return mcp2cli
+
+    def test_foreign_file_with_the_same_name_is_left_alone(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        victim = home / ".local" / "bin" / "jq"
+        victim.write_text("#!/bin/sh\n# the user's own jq\n")
+
+        m = self._baked(monkeypatch, tmp_path, "jq")
+        m._bake_remove(["jq"])
+
+        assert victim.exists()
+        assert "the user's own jq" in victim.read_text()
+        assert m._load_baked("jq") is None
+
+    def test_wrapper_we_installed_is_removed(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool"])
+        wrapper = home / ".local" / "bin" / "mytool"
+        assert wrapper.exists()
+
+        m._bake_remove(["mytool"])
+        assert not wrapper.exists()
+
+    def test_wrapper_installed_with_custom_dir_is_removed(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        wrapper = custom / "mytool"
+        assert wrapper.exists()
+
+        m._bake_remove(["mytool"])
+        assert not wrapper.exists()
+
+    def test_custom_dir_install_does_not_touch_default_dir(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        # An unrelated binary sits at the default location under the same name.
+        decoy = home / ".local" / "bin" / "mytool"
+        decoy.write_text("#!/bin/sh\n# unrelated\n")
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        m._bake_remove(["mytool"])
+
+        assert not (custom / "mytool").exists()
+        assert decoy.exists()
+
+    def test_install_records_the_wrapper_path(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        custom = tmp_path / "scripts"
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_install(["mytool", "--dir", str(custom)])
+        assert m._load_baked("mytool")["wrapper_path"] == str(custom / "mytool")
+
+    def test_remove_succeeds_when_no_wrapper_was_installed(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        m = self._baked(monkeypatch, tmp_path, "mytool")
+        m._bake_remove(["mytool"])
+        assert m._load_baked("mytool") is None

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -549,3 +549,47 @@ class TestBakeInstall:
         )
         assert r.returncode == 0
         assert "may not be in your PATH" not in r.stdout
+
+
+class TestShowMasksOAuthSecret:
+    """`bake show` must never print oauth_client_secret in the clear."""
+
+    def _create(self, cfg_dir, cache_dir, name, secret):
+        r = _run(
+            "bake", "create", name,
+            "--spec", "https://api.example.com/openapi.json",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+            config_dir=cfg_dir, cache_dir=cache_dir,
+        )
+        assert r.returncode == 0, r.stderr
+
+    def test_literal_secret_is_masked(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-lit", "sk-super-secret-value")
+        r = _run("bake", "show", "mask-lit", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert r.returncode == 0, r.stderr
+        assert "sk-super-secret-value" not in r.stdout
+        cfg = json.loads(r.stdout)
+        assert cfg["oauth_client_secret"] == "sk-s****"
+        # The client id is not a secret and stays diagnosable.
+        assert cfg["oauth_client_id"] == "my-client-id"
+
+    def test_short_secret_fully_masked(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-short", "abcd")
+        r = _run("bake", "show", "mask-short", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert json.loads(r.stdout)["oauth_client_secret"] == "****"
+
+    def test_env_reference_stays_readable(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-env", "env:OAUTH_SECRET")
+        r = _run("bake", "show", "mask-env", config_dir=cfg_dir, cache_dir=cache_dir)
+        assert json.loads(r.stdout)["oauth_client_secret"] == "env:OAUTH_SECRET"
+
+    def test_stored_config_is_untouched(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        self._create(cfg_dir, cache_dir, "mask-store", "sk-super-secret-value")
+        _run("bake", "show", "mask-store", config_dir=cfg_dir, cache_dir=cache_dir)
+        stored = json.loads((cfg_dir / "baked.json").read_text())
+        assert stored["mask-store"]["oauth_client_secret"] == "sk-super-secret-value"

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -551,45 +551,93 @@ class TestBakeInstall:
         assert "may not be in your PATH" not in r.stdout
 
 
-class TestShowMasksOAuthSecret:
-    """`bake show` must never print oauth_client_secret in the clear."""
+class TestBakeShowMasking:
+    """`bake show` output must be safe to paste, without changing what runs."""
 
-    def _create(self, cfg_dir, cache_dir, name, secret):
+    def _create(self, cfg_dir, cache_dir, name, *extra):
         r = _run(
             "bake", "create", name,
             "--spec", "https://api.example.com/openapi.json",
-            "--oauth-client-id", "my-client-id",
-            "--oauth-client-secret", secret,
+            *extra,
             config_dir=cfg_dir, cache_dir=cache_dir,
         )
         assert r.returncode == 0, r.stderr
 
-    def test_literal_secret_is_masked(self, tmp_path):
-        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-lit", "sk-super-secret-value")
-        r = _run("bake", "show", "mask-lit", config_dir=cfg_dir, cache_dir=cache_dir)
+    def _show(self, cfg_dir, cache_dir, name):
+        r = _run("bake", "show", name, config_dir=cfg_dir, cache_dir=cache_dir)
         assert r.returncode == 0, r.stderr
-        assert "sk-super-secret-value" not in r.stdout
-        cfg = json.loads(r.stdout)
-        assert cfg["oauth_client_secret"] == "sk-s****"
+        return r, json.loads(r.stdout)
+
+    @staticmethod
+    def _assert_redacted(shown, secret, output):
+        # The secret must never reach a terminal, and whatever hint is left
+        # behind may be no more than a short prefix of it.
+        assert secret not in output
+        visible = shown.rstrip("*")
+        assert len(visible) <= 4, shown
+        assert secret.startswith(visible), shown
+
+    def test_oauth_client_secret_is_redacted(self, tmp_path):
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        secret = "sk-super-secret-value"
+        self._create(
+            cfg_dir, cache_dir, "mask-lit",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+        )
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-lit")
+        self._assert_redacted(cfg["oauth_client_secret"], secret, r.stdout + r.stderr)
         # The client id is not a secret and stays diagnosable.
         assert cfg["oauth_client_id"] == "my-client-id"
 
-    def test_short_secret_fully_masked(self, tmp_path):
+    def test_secret_shorter_than_the_hint_is_not_disclosed(self, tmp_path):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-short", "abcd")
-        r = _run("bake", "show", "mask-short", config_dir=cfg_dir, cache_dir=cache_dir)
-        assert json.loads(r.stdout)["oauth_client_secret"] == "****"
+        self._create(
+            cfg_dir, cache_dir, "mask-short",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", "abcd",
+        )
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-short")
+        assert "abcd" not in r.stdout + r.stderr
+        assert cfg["oauth_client_secret"].strip("*") == ""
 
-    def test_env_reference_stays_readable(self, tmp_path):
+    def test_auth_header_value_is_redacted(self, tmp_path):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-env", "env:OAUTH_SECRET")
-        r = _run("bake", "show", "mask-env", config_dir=cfg_dir, cache_dir=cache_dir)
-        assert json.loads(r.stdout)["oauth_client_secret"] == "env:OAUTH_SECRET"
+        token = "Bearer tok-abcdef123456"
+        self._create(cfg_dir, cache_dir, "mask-hdr", "--auth-header", f"Authorization:{token}")
+        r, cfg = self._show(cfg_dir, cache_dir, "mask-hdr")
+        (header_name, shown), = cfg["auth_headers"]
+        # Header names are not secrets — you need them to diagnose auth.
+        assert header_name == "Authorization"
+        self._assert_redacted(shown, token, r.stdout + r.stderr)
 
-    def test_stored_config_is_untouched(self, tmp_path):
+    @pytest.mark.parametrize("ref", ["env:OAUTH_SECRET", "file:/run/secrets/oauth"])
+    def test_indirect_references_stay_readable(self, tmp_path, ref):
         cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
-        self._create(cfg_dir, cache_dir, "mask-store", "sk-super-secret-value")
-        _run("bake", "show", "mask-store", config_dir=cfg_dir, cache_dir=cache_dir)
-        stored = json.loads((cfg_dir / "baked.json").read_text())
-        assert stored["mask-store"]["oauth_client_secret"] == "sk-super-secret-value"
+        self._create(
+            cfg_dir, cache_dir, "mask-ref",
+            "--oauth-client-secret", ref,
+            "--auth-header", f"X-Key:{ref}",
+        )
+        _, cfg = self._show(cfg_dir, cache_dir, "mask-ref")
+        assert cfg["oauth_client_secret"] == ref
+        assert cfg["auth_headers"] == [["X-Key", ref]]
+
+    def test_masking_does_not_change_what_the_baked_tool_sends(self, tmp_path, monkeypatch):
+        import mcp2cli
+
+        cfg_dir, cache_dir = tmp_path / "config", tmp_path / "cache"
+        secret, token = "sk-super-secret-value", "Bearer tok-abcdef123456"
+        self._create(
+            cfg_dir, cache_dir, "mask-run",
+            "--oauth-client-id", "my-client-id",
+            "--oauth-client-secret", secret,
+            "--auth-header", f"Authorization:{token}",
+        )
+        self._show(cfg_dir, cache_dir, "mask-run")
+
+        # What `mcp2cli @mask-run ...` would run with: the real credentials.
+        monkeypatch.setattr(mcp2cli, "BAKED_FILE", cfg_dir / "baked.json")
+        argv = _baked_to_argv(_load_baked("mask-run"))
+        assert secret in argv
+        assert f"Authorization:{token}" in argv

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -273,3 +273,64 @@ class TestMCPStdioCaching:
         r = self._run_mcp("--cache-ttl", "1", "echo", "--message", "refreshed", cache_dir=cd)
         assert r.returncode == 0
         assert "refreshed" in r.stdout
+
+
+class TestCacheCorruptionResilience:
+    """A damaged cache entry must cost one refetch, not every later run."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        import mcp2cli
+        monkeypatch.setattr(mcp2cli, "CACHE_DIR", tmp_path)
+        return mcp2cli
+
+    def test_truncated_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text('{"paths": {"/a"')
+        assert m.load_cached("abc", 3600) is None
+
+    def test_empty_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text("")
+        assert m.load_cached("abc", 3600) is None
+
+    def test_non_utf8_entry_is_treated_as_a_miss(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_bytes(b"\xff\xfe\x00garbage")
+        assert m.load_cached("abc", 3600) is None
+
+    def test_corrupt_entry_is_overwritten_by_the_next_save(
+        self, monkeypatch, tmp_path
+    ):
+        m = self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "abc.json").write_text("not json at all")
+        assert m.load_cached("abc", 3600) is None
+        m.save_cache("abc", {"paths": {"/pets": {}}})
+        assert m.load_cached("abc", 3600) == {"paths": {"/pets": {}}}
+
+    def test_valid_entry_still_round_trips(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert m.load_cached("abc", 3600) == {"hello": "world"}
+
+    def test_expiry_still_honoured(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert m.load_cached("abc", 0) is None
+
+    def test_save_leaves_no_temp_files_behind(self, monkeypatch, tmp_path):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"hello": "world"})
+        assert [q.name for q in tmp_path.iterdir()] == ["abc.json"]
+
+    def test_failed_serialisation_leaves_previous_entry_intact(
+        self, monkeypatch, tmp_path
+    ):
+        m = self._isolate(monkeypatch, tmp_path)
+        m.save_cache("abc", {"good": True})
+        # Serialisation happens before the file is touched, so an
+        # unserialisable payload cannot destroy the entry that is already
+        # on disk.
+        with pytest.raises(TypeError):
+            m.save_cache("abc", {"bad": object()})
+        assert m.load_cached("abc", 3600) == {"good": True}
+        assert [q.name for q in tmp_path.iterdir()] == ["abc.json"]

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,5 +1,6 @@
 """Tests for GraphQL support."""
 
+import argparse
 import json
 import subprocess
 import sys
@@ -394,3 +395,106 @@ class TestGraphQLIntegration:
         assert r.returncode == 0
         data = json.loads(r.stdout)
         assert isinstance(data, list)
+
+
+def _name_collision_schema(query_fields=(), mutation_fields=()):
+    """Minimal introspection schema with the given Query/Mutation field names."""
+    def field(name):
+        return {
+            "name": name,
+            "description": None,
+            "args": [],
+            "type": {"kind": "SCALAR", "name": "String", "ofType": None},
+        }
+
+    return {
+        "queryType": {"name": "Query"},
+        "mutationType": {"name": "Mutation"} if mutation_fields else None,
+        "types": [
+            {
+                "name": "Query",
+                "kind": "OBJECT",
+                "fields": [field(n) for n in query_fields],
+            },
+            {
+                "name": "Mutation",
+                "kind": "OBJECT",
+                "fields": [field(n) for n in mutation_fields],
+            },
+        ],
+    }
+
+
+class TestGraphQLNameCollisions:
+    """Fields that kebab-case onto the same name must stay addressable."""
+
+    def test_three_way_kebab_collision_stays_unique(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "GetUser"]
+        )
+        names = [c.name for c in mcp2cli.extract_graphql_commands(schema)]
+        assert len(names) == len(set(names))
+        assert names == ["get-user", "query-get-user", "query-get-user-2"]
+
+    def test_three_way_collision_builds_a_parser(self):
+        # Duplicate subparser names raise argparse.ArgumentError, which took
+        # down every command rather than just the colliding ones.
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "GetUser"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        parser = mcp2cli.build_argparse(cmds, argparse.ArgumentParser(add_help=False))
+        for cmd in cmds:
+            assert parser.parse_args([cmd.name])._cmd is cmd
+
+    def test_alias_never_shadows_another_fields_natural_name(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user", "queryGetUser"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        by_field = {c.graphql_field_name: c.name for c in cmds}
+        # queryGetUser owns `query-get-user`; the alias for get_user must
+        # not take it.
+        assert by_field["queryGetUser"] == "query-get-user"
+        assert by_field["getUser"] == "get-user"
+        assert len(set(by_field.values())) == 3
+
+    def test_query_mutation_overlap_still_prefixed_symmetrically(self):
+        schema = _name_collision_schema(
+            query_fields=["user"], mutation_fields=["user"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        assert [c.name for c in cmds] == ["query-user", "mutation-user"]
+
+    def test_cross_type_kebab_collision_is_disambiguated(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser"], mutation_fields=["get_user"]
+        )
+        names = [c.name for c in mcp2cli.extract_graphql_commands(schema)]
+        assert len(names) == len(set(names))
+        assert names == ["get-user", "mutation-get-user"]
+
+    def test_introspection_fields_still_skipped(self):
+        schema = _name_collision_schema(
+            query_fields=["__schema", "__type", "user"]
+        )
+        assert [c.name for c in mcp2cli.extract_graphql_commands(schema)] == ["user"]
+
+    def test_non_colliding_names_are_untouched(self):
+        schema = _name_collision_schema(
+            query_fields=["listUsers"], mutation_fields=["createUser"]
+        )
+        assert [c.name for c in mcp2cli.extract_graphql_commands(schema)] == [
+            "list-users",
+            "create-user",
+        ]
+
+    def test_field_metadata_survives_renaming(self):
+        schema = _name_collision_schema(
+            query_fields=["getUser", "get_user"]
+        )
+        cmds = mcp2cli.extract_graphql_commands(schema)
+        # The wire name is what actually goes into the document, so it must
+        # be preserved even when the CLI name is aliased.
+        assert [c.graphql_field_name for c in cmds] == ["getUser", "get_user"]
+        assert all(c.graphql_operation_type == "query" for c in cmds)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -810,3 +810,68 @@ class TestExtractContentParts:
             {"type": "resource_link", "uri": "probe://linked", "name": "linked-doc"},
         ]
         assert _extract_content_parts(blocks) == "see:\nlinked-doc: probe://linked"
+
+
+class TestResolveRefsRobustness:
+    """A spec we did not write must not crash ref resolution."""
+
+    def test_dangling_ref_does_not_raise(self, capsys):
+        spec = {
+            "paths": {
+                "/x": {
+                    "get": {
+                        "parameters": [
+                            {"$ref": "#/components/parameters/Missing"}
+                        ]
+                    }
+                }
+            },
+        }
+        resolved = resolve_refs(spec)
+        # Left unresolved -- the same shape a cycle or external ref produces.
+        assert resolved["paths"]["/x"]["get"]["parameters"][0] == {
+            "$ref": "#/components/parameters/Missing"
+        }
+        err = capsys.readouterr().err
+        assert "unresolvable $ref" in err
+        assert "#/components/parameters/Missing" in err
+
+    def test_dangling_ref_warns_once(self, capsys):
+        ref = {"$ref": "#/nope"}
+        spec = {"paths": {"/a": {"get": {"x": dict(ref)}},
+                          "/b": {"get": {"x": dict(ref)}}}}
+        resolve_refs(spec)
+        assert capsys.readouterr().err.count("unresolvable $ref") == 1
+
+    def test_json_pointer_escapes_are_decoded(self):
+        # RFC 6901: ~1 -> /  and  ~0 -> ~
+        spec = {
+            "components": {"a/b": {"c~d": {"type": "integer"}}},
+            "paths": {
+                "/x": {
+                    "get": {
+                        "schema": {"$ref": "#/components/a~1b/c~0d"}
+                    }
+                }
+            },
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+
+    def test_array_index_tokens(self):
+        spec = {
+            "shared": [{"type": "string"}, {"type": "integer"}],
+            "paths": {
+                "/x": {"get": {"schema": {"$ref": "#/shared/1"}}}
+            },
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+
+    def test_ref_through_non_container_is_unresolved(self):
+        spec = {
+            "leaf": 42,
+            "paths": {"/x": {"get": {"schema": {"$ref": "#/leaf/deeper"}}}},
+        }
+        resolved = resolve_refs(spec)
+        assert resolved["paths"]["/x"]["get"]["schema"] == {"$ref": "#/leaf/deeper"}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -893,7 +893,7 @@ class TestResolveRefsRobustness:
         spec = self._spec("#/shared/2", shared=[{"type": "string"}])
         assert self._schema(resolve_refs(spec)) == {"$ref": "#/shared/2"}
 
-    def test_huge_index_token_does_not_depend_on_int_limit(self, capsys):
+    def test_huge_index_token_does_not_depend_on_int_limit(self):
         ref = "#/shared/" + "9" * 6000
         spec = self._spec(ref, shared=[{"type": "string"}])
         limit = sys.get_int_max_str_digits()
@@ -903,9 +903,6 @@ class TestResolveRefsRobustness:
         finally:
             sys.set_int_max_str_digits(limit)
         assert self._schema(resolved) == {"$ref": ref}
-        # A spec-controlled ref must not flood stderr with one huge line.
-        err = capsys.readouterr().err
-        assert 0 < len(err) < 400, len(err)
 
     def test_numeric_and_signed_dict_keys_still_resolve(self):
         # Array-index screening must not reach dict keys, which are plain
@@ -941,15 +938,28 @@ class TestResolveRefsRobustness:
         }
         assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
-    def test_literal_percent_name_wins_over_decoded_one(self):
+    def test_percent_decoding_is_the_only_reading_of_a_fragment(self):
+        # Both names exist, so the ref is only unambiguous because the
+        # fragment is decoded exactly once: %20 is a space, and a literal
+        # '%' has to arrive as %25.
+        components = {
+            "Pet%20Dog": {"type": "integer"},
+            "Pet Dog": {"type": "string"},
+        }
+        spec = self._spec("#/components/Pet%20Dog", components=components)
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
+        spec = self._spec("#/components/Pet%2520Dog", components=components)
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_encoded_separator_is_a_separator(self):
+        # %2F decodes to a separator, not to a slash inside a member name --
+        # a name holding a slash is ~1 (or %7E1).
         spec = self._spec(
-            "#/components/Pet%20Dog",
-            components={
-                "Pet%20Dog": {"type": "integer"},
-                "Pet Dog": {"type": "string"},
-            },
+            "#/components%2Fa/b", components={"a": {"b": {"type": "integer"}}}
         )
         assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        spec = self._spec("#/components/a%7E1b", components={"a/b": {"type": "string"}})
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
 
     def test_ref_through_non_container_is_unresolved(self):
         spec = self._spec("#/leaf/deeper", leaf=42)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import shutil
+import sys
 
 from mcp2cli import (
     ParamDef,
@@ -815,7 +816,16 @@ class TestExtractContentParts:
 class TestResolveRefsRobustness:
     """A spec we did not write must not crash ref resolution."""
 
-    def test_dangling_ref_does_not_raise(self, capsys):
+    @staticmethod
+    def _spec(ref, **root):
+        """A spec whose only ``$ref`` sits at paths./x.get.schema."""
+        return {"paths": {"/x": {"get": {"schema": {"$ref": ref}}}}, **root}
+
+    @staticmethod
+    def _schema(resolved):
+        return resolved["paths"]["/x"]["get"]["schema"]
+
+    def test_dangling_ref_is_left_unresolved_and_named(self, capsys):
         spec = {
             "paths": {
                 "/x": {
@@ -832,46 +842,120 @@ class TestResolveRefsRobustness:
         assert resolved["paths"]["/x"]["get"]["parameters"][0] == {
             "$ref": "#/components/parameters/Missing"
         }
-        err = capsys.readouterr().err
-        assert "unresolvable $ref" in err
-        assert "#/components/parameters/Missing" in err
+        assert "#/components/parameters/Missing" in capsys.readouterr().err
 
-    def test_dangling_ref_warns_once(self, capsys):
+    def test_dangling_ref_reported_once_per_ref(self, capsys):
         ref = {"$ref": "#/nope"}
         spec = {"paths": {"/a": {"get": {"x": dict(ref)}},
                           "/b": {"get": {"x": dict(ref)}}}}
         resolve_refs(spec)
-        assert capsys.readouterr().err.count("unresolvable $ref") == 1
+        assert capsys.readouterr().err.count("#/nope") == 1
+
+    def test_resolvable_ref_is_silent(self, capsys):
+        spec = self._spec("#/components/Ok", components={"Ok": {"type": "integer"}})
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        assert capsys.readouterr().err == ""
 
     def test_json_pointer_escapes_are_decoded(self):
         # RFC 6901: ~1 -> /  and  ~0 -> ~
-        spec = {
-            "components": {"a/b": {"c~d": {"type": "integer"}}},
-            "paths": {
-                "/x": {
-                    "get": {
-                        "schema": {"$ref": "#/components/a~1b/c~0d"}
-                    }
-                }
-            },
-        }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+        spec = self._spec(
+            "#/components/a~1b/c~0d",
+            components={"a/b": {"c~d": {"type": "integer"}}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
-    def test_array_index_tokens(self):
+    def test_tilde_escape_decoding_order(self):
+        # ~01 is the literal name "~1", never the separator "/".
+        spec = self._spec(
+            "#/components/~01",
+            components={"~1": {"type": "integer"}, "/": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_array_index_tokens_resolve(self):
+        shared = [{"type": "string"}, {"type": "integer"}]
+        assert self._schema(
+            resolve_refs(self._spec("#/shared/0", shared=shared))
+        ) == {"type": "string"}
+        assert self._schema(
+            resolve_refs(self._spec("#/shared/1", shared=shared))
+        ) == {"type": "integer"}
+
+    def test_malformed_array_indices_select_nothing(self):
+        # int() would take every one of these -- "-1" would hand back the
+        # *last* element, "01"/" 1"/"1_0"/"\u0661" some other element.
+        for token in ["-1", "+1", "01", " 1", "1 ", "1_0", "\u0661", "1.0", ""]:
+            ref = f"#/shared/{token}"
+            spec = self._spec(ref, shared=[{"type": "string"}, {"type": "integer"}])
+            assert self._schema(resolve_refs(spec)) == {"$ref": ref}, token
+
+    def test_out_of_range_array_index_selects_nothing(self):
+        spec = self._spec("#/shared/2", shared=[{"type": "string"}])
+        assert self._schema(resolve_refs(spec)) == {"$ref": "#/shared/2"}
+
+    def test_huge_index_token_does_not_depend_on_int_limit(self, capsys):
+        ref = "#/shared/" + "9" * 6000
+        spec = self._spec(ref, shared=[{"type": "string"}])
+        limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(0)  # 0 disables CPython's conversion guard
+        try:
+            resolved = resolve_refs(spec)
+        finally:
+            sys.set_int_max_str_digits(limit)
+        assert self._schema(resolved) == {"$ref": ref}
+        # A spec-controlled ref must not flood stderr with one huge line.
+        err = capsys.readouterr().err
+        assert 0 < len(err) < 400, len(err)
+
+    def test_numeric_and_signed_dict_keys_still_resolve(self):
+        # Array-index screening must not reach dict keys, which are plain
+        # strings: OpenAPI response maps are keyed "200", "404", ...
+        spec = self._spec(
+            "#/responses/200",
+            responses={"200": {"type": "integer"}, "-1": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        spec = self._spec(
+            "#/responses/-1",
+            responses={"200": {"type": "integer"}, "-1": {"type": "string"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "string"}
+
+    def test_percent_encoded_fragment_resolves(self):
+        # RFC 6901 section 6: a pointer inside a URI fragment is
+        # percent-encoded, so a space arrives as %20 and "{" as %7B.
+        spec = self._spec(
+            "#/components/Pet%20Dog",
+            components={"Pet Dog": {"type": "integer"}},
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+        # "{" and "}" are not legal fragment characters either, so a legal
+        # ref to a templated path item arrives as ~1pets~1%7Bid%7D.
         spec = {
-            "shared": [{"type": "string"}, {"type": "integer"}],
             "paths": {
-                "/x": {"get": {"schema": {"$ref": "#/shared/1"}}}
-            },
+                "/pets/{id}": {"get": {"type": "integer"}},
+                "/x": {
+                    "get": {"schema": {"$ref": "#/paths/~1pets~1%7Bid%7D/get"}}
+                },
+            }
         }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"type": "integer"}
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
+
+    def test_literal_percent_name_wins_over_decoded_one(self):
+        spec = self._spec(
+            "#/components/Pet%20Dog",
+            components={
+                "Pet%20Dog": {"type": "integer"},
+                "Pet Dog": {"type": "string"},
+            },
+        )
+        assert self._schema(resolve_refs(spec)) == {"type": "integer"}
 
     def test_ref_through_non_container_is_unresolved(self):
-        spec = {
-            "leaf": 42,
-            "paths": {"/x": {"get": {"schema": {"$ref": "#/leaf/deeper"}}}},
-        }
-        resolved = resolve_refs(spec)
-        assert resolved["paths"]["/x"]["get"]["schema"] == {"$ref": "#/leaf/deeper"}
+        spec = self._spec("#/leaf/deeper", leaf=42)
+        assert self._schema(resolve_refs(spec)) == {"$ref": "#/leaf/deeper"}
+
+    def test_external_ref_is_left_intact(self, capsys):
+        spec = self._spec("other.yaml#/components/Pet")
+        assert self._schema(resolve_refs(spec)) == {"$ref": "other.yaml#/components/Pet"}
+        assert capsys.readouterr().err == ""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -717,3 +717,18 @@ class TestConnectionErrors:
         )
         assert r.returncode != 0
         assert "Traceback" in r.stderr
+
+
+    def test_run_mcp_clean_server_disconnect(self, capsys):
+        import anyio
+        from mcp2cli import _run_mcp_clean
+
+        async def throw_disconnect():
+            raise anyio.EndOfStream("Server disconnected")
+
+        with pytest.raises(SystemExit) as caught:
+            _run_mcp_clean(throw_disconnect, "test")
+        
+        assert caught.value.code == 1
+        captured = capsys.readouterr()
+        assert "the server disconnected unexpectedly" in captured.err

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -29,6 +29,11 @@ def _code_state(result):
     return (result.code, result.state)
 
 
+def _result_iss(result):
+    """The RFC 9207 issuer a callback_handler forwarded, if the SDK carries it."""
+    return None if isinstance(result, tuple) else getattr(result, "iss", None)
+
+
 class TestResolveSecret:
     """Tests for resolve_secret helper."""
 
@@ -1006,29 +1011,39 @@ class TestParseOAuthCallbackInput:
     """Tests for parsing a pasted OAuth callback URL (issue #71)."""
 
     def test_full_url(self):
-        code, state = mcp2cli._parse_oauth_callback_input(
+        code, state, iss = mcp2cli._parse_oauth_callback_input(
             "http://127.0.0.1:5311/callback?code=abc123&state=xyz789"
         )
-        assert (code, state) == ("abc123", "xyz789")
+        assert (code, state, iss) == ("abc123", "xyz789", None)
 
     def test_query_string_only(self):
         """A user who copied only the query part still gets through."""
         assert mcp2cli._parse_oauth_callback_input("code=abc&state=xyz") == (
             "abc",
             "xyz",
+            None,
         )
 
     def test_strips_surrounding_whitespace_and_quotes(self):
-        code, state = mcp2cli._parse_oauth_callback_input(
+        code, state, _ = mcp2cli._parse_oauth_callback_input(
             '  "http://127.0.0.1:1/callback?code=a&state=b"\n'
         )
         assert (code, state) == ("a", "b")
 
     def test_percent_encoded_code_is_decoded(self):
-        code, _ = mcp2cli._parse_oauth_callback_input(
+        code, _, _ = mcp2cli._parse_oauth_callback_input(
             "http://127.0.0.1:1/callback?code=a%2Fb%3Dc&state=s"
         )
         assert code == "a/b=c"
+
+    def test_iss_is_extracted_and_decoded(self):
+        """RFC 9207: the SDK validates iss when the server advertises it, so a
+        dropped iss fails the flow with 'Authorization response missing iss'."""
+        code, state, iss = mcp2cli._parse_oauth_callback_input(
+            "http://127.0.0.1:1/callback?code=a&state=b"
+            "&iss=https%3A%2F%2Fclerk.example.com"
+        )
+        assert (code, state, iss) == ("a", "b", "https://clerk.example.com")
 
     def test_error_redirect_raises_with_description(self):
         with pytest.raises(RuntimeError, match=r"access_denied \(user said no\)"):
@@ -1059,7 +1074,7 @@ class TestPromptOAuthCallback:
         monkeypatch.setattr(
             sys, "stdin", io.StringIO("http://127.0.0.1:1/callback?code=c1&state=s1\n")
         )
-        assert mcp2cli._prompt_oauth_callback() == ("c1", "s1")
+        assert mcp2cli._prompt_oauth_callback() == ("c1", "s1", None)
         assert "Paste the full callback URL" in capsys.readouterr().err
 
     def test_reprompts_after_malformed_paste(self, monkeypatch, capsys):
@@ -1069,7 +1084,7 @@ class TestPromptOAuthCallback:
             "stdin",
             io.StringIO("not-a-url\nhttp://127.0.0.1:1/callback?code=c2&state=s2\n"),
         )
-        assert mcp2cli._prompt_oauth_callback() == ("c2", "s2")
+        assert mcp2cli._prompt_oauth_callback() == ("c2", "s2", None)
         assert "attempt(s) left" in capsys.readouterr().err
 
     def test_gives_up_after_exhausting_attempts(self, monkeypatch):
@@ -1139,6 +1154,29 @@ class TestManualCallbackProvider:
             sys, "stdin", io.StringIO("http://127.0.0.1:1/callback?code=zz&state=yy\n")
         )
         assert _code_state(anyio.run(provider.context.callback_handler)) == ("zz", "yy")
+
+    def test_manual_callback_handler_forwards_iss(self, tmp_path, monkeypatch):
+        """Servers that send iss (RFC 9207) fail the token exchange unless the
+        handler forwards it to the SDK."""
+        import anyio
+
+        monkeypatch.setattr(mcp2cli, "OAUTH_DIR", tmp_path / "oauth")
+        provider = mcp2cli.build_oauth_provider(
+            "https://example.com/mcp", manual_callback=True
+        )
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                "http://127.0.0.1:1/callback?code=zz&state=yy"
+                "&iss=https%3A%2F%2Fissuer.example.com\n"
+            ),
+        )
+        result = anyio.run(provider.context.callback_handler)
+
+        assert _code_state(result) == ("zz", "yy")
+        if not isinstance(result, tuple):
+            assert _result_iss(result) == "https://issuer.example.com"
 
     def test_manual_redirect_handler_prints_url_and_skips_browser(
         self, tmp_path, monkeypatch, capsys

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,106 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _path_level_param_spec():
+    """A path item that declares its parameters once, for every operation."""
+    return {
+        "openapi": "3.0.0",
+        "paths": {
+            "/users/{userId}": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "name": "verbose",
+                        "in": "query",
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "get": {"operationId": "getUser", "responses": {}},
+                "delete": {"operationId": "deleteUser", "responses": {}},
+            }
+        },
+    }
+
+
+class TestPathLevelParameters:
+    """OpenAPI 3.x: `parameters` on a path item apply to every operation."""
+
+    def test_inherited_by_every_operation(self):
+        cmds = extract_openapi_commands(_path_level_param_spec())
+        by_name = {c.name: c for c in cmds}
+        assert set(by_name) == {"get-user", "delete-user"}
+        for cmd in by_name.values():
+            locations = {p.original_name: p.location for p in cmd.params}
+            assert locations == {"userId": "path", "verbose": "query"}
+
+    def test_path_placeholder_is_substituted(self):
+        cmd = extract_openapi_commands(_path_level_param_spec())[0]
+        args = argparse.Namespace(user_id="u-42", verbose=None, stdin=False)
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert path == "/users/u-42"
+
+    def test_operation_level_overrides_inherited(self):
+        spec = _path_level_param_spec()
+        spec["paths"]["/users/{userId}"]["get"]["parameters"] = [
+            {
+                "name": "userId",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "integer"},
+            }
+        ]
+        cmds = {c.name: c for c in extract_openapi_commands(spec)}
+        get_param = next(
+            p for p in cmds["get-user"].params if p.original_name == "userId"
+        )
+        # The operation's narrower declaration wins...
+        assert get_param.python_type is int
+        # ...while the sibling operation keeps the inherited one.
+        del_param = next(
+            p for p in cmds["delete-user"].params if p.original_name == "userId"
+        )
+        assert del_param.python_type is str
+        # An override must not drop the other inherited parameters.
+        assert {p.original_name for p in cmds["get-user"].params} == {
+            "userId",
+            "verbose",
+        }
+
+    def test_operation_level_only_still_works(self):
+        spec = {
+            "openapi": "3.0.0",
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "parameters": [
+                            {"name": "limit", "in": "query",
+                             "schema": {"type": "integer"}}
+                        ],
+                        "responses": {},
+                    }
+                }
+            },
+        }
+        cmd = extract_openapi_commands(spec)[0]
+        assert [p.original_name for p in cmd.params] == ["limit"]
+
+    def test_malformed_parameter_entries_are_skipped(self):
+        spec = {
+            "openapi": "3.0.0",
+            "paths": {
+                "/x": {
+                    "parameters": ["not-a-dict", {"no_name": True}],
+                    "get": {"operationId": "getX", "responses": {}},
+                }
+            },
+        }
+        cmd = extract_openapi_commands(spec)[0]
+        assert cmd.params == []

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,81 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _collision_spec(*entries):
+    """Build a spec from (path, method, operationId) triples."""
+    paths: dict = {}
+    for path, method, op_id in entries:
+        op: dict = {"responses": {}}
+        if op_id is not None:
+            op["operationId"] = op_id
+        paths.setdefault(path, {})[method] = op
+    return {"openapi": "3.0.0", "paths": paths}
+
+
+class TestCommandNameCollisions:
+    """Colliding OpenAPI command names must stay unique and addressable."""
+
+    def test_three_way_collision_stays_unique(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThing"),
+        )
+        names = [c.name for c in extract_openapi_commands(spec)]
+        assert len(names) == len(set(names))
+        assert names == ["do-thing", "do-thing-post", "do-thing-post-2"]
+
+    def test_three_way_collision_builds_a_parser(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThing"),
+        )
+        cmds = extract_openapi_commands(spec)
+        parser = build_argparse(cmds, argparse.ArgumentParser(add_help=False))
+        for cmd in cmds:
+            args = parser.parse_args([cmd.name])
+            assert args._cmd is cmd
+
+    def test_method_suffix_used_when_free(self):
+        spec = _collision_spec(
+            ("/a", "get", "doThing"),
+            ("/b", "post", "doThing"),
+        )
+        assert [c.name for c in extract_openapi_commands(spec)] == [
+            "do-thing",
+            "do-thing-post",
+        ]
+
+    def test_alias_never_shadows_another_natural_name(self):
+        spec = _collision_spec(
+            ("/a", "post", "doThing"),
+            ("/b", "post", "doThing"),
+            ("/c", "post", "doThingPost"),
+        )
+        cmds = extract_openapi_commands(spec)
+        names = [c.name for c in cmds]
+        assert len(names) == len(set(names))
+        by_op = {c.path: c.name for c in cmds}
+        assert by_op["/c"] == "do-thing-post"
+        assert by_op["/b"] == "do-thing-post-2"
+
+    def test_pathless_slug_names_still_unique(self):
+        spec = _collision_spec(
+            ("/items", "get", None),
+            ("/items", "post", None),
+        )
+        names = [c.name for c in extract_openapi_commands(spec)]
+        assert names == ["get-items", "post-items"]
+
+    def test_no_collision_leaves_names_untouched(self):
+        spec = _collision_spec(
+            ("/a", "get", "listThings"),
+            ("/b", "post", "createThing"),
+        )
+        assert [c.name for c in extract_openapi_commands(spec)] == [
+            "list-things",
+            "create-thing",
+        ]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -483,3 +483,107 @@ class TestCollectMultipartParams:
         _, _, _, body, files = _collect_openapi_params(cmd, args)
         assert files is None
         assert body == {"caption": "hello"}
+
+
+def _mixed_location_spec(method="post"):
+    """An operation carrying query, header, path and body parameters at once."""
+    return {
+        "openapi": "3.0.0",
+        "paths": {
+            "/tenants/{tenantId}/items": {
+                method: {
+                    "operationId": "createItem",
+                    "parameters": [
+                        {"name": "tenantId", "in": "path", "required": True,
+                         "schema": {"type": "string"}},
+                        {"name": "dryRun", "in": "query",
+                         "schema": {"type": "string"}},
+                        {"name": "region", "in": "query",
+                         "schema": {"type": "string"}},
+                        {"name": "X-Trace", "in": "header",
+                         "schema": {"type": "string"}},
+                    ],
+                    "requestBody": {"content": {"application/json": {"schema": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                            "name": {"type": "string"},
+                            "qty": {"type": "integer"},
+                        },
+                    }}}},
+                    "responses": {},
+                }
+            }
+        },
+    }
+
+
+class TestQueryParamsStayOutOfBody:
+    """Query parameters belong in the URL, never duplicated into the body."""
+
+    def test_query_param_not_copied_into_json_body(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name="widget", qty=3, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget", "qty": 3}
+        assert query == {"region": "eu"}
+        assert path == "/tenants/acme/items"
+
+    def test_header_and_path_still_excluded_from_body(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run="yes", region=None, x_trace="abc123",
+            name="widget", qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget"}
+        assert headers == {"X-Trace": "abc123"}
+        assert query == {"dryRun": "yes"}
+        assert "tenantId" not in body
+
+    def test_body_becomes_none_when_only_query_supplied(self):
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body is None
+        assert query == {"region": "eu"}
+
+    def test_query_still_collected_with_stdin_body(self, monkeypatch):
+        import io
+        cmd = extract_openapi_commands(_mixed_location_spec())[0]
+        monkeypatch.setattr(sys, "stdin", io.StringIO('{"name": "from-stdin"}'))
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=True,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "from-stdin"}
+        assert query == {"region": "eu"}
+
+    def test_delete_verb_behaves_the_same(self):
+        cmd = extract_openapi_commands(_mixed_location_spec("delete"))[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name="widget", qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body == {"name": "widget"}
+        assert query == {"region": "eu"}
+
+    def test_get_verb_unaffected(self):
+        spec = _mixed_location_spec("get")
+        cmd = extract_openapi_commands(spec)[0]
+        args = argparse.Namespace(
+            tenant_id="acme", dry_run=None, region="eu", x_trace=None,
+            name=None, qty=None, stdin=False,
+        )
+        path, query, headers, body, files = _collect_openapi_params(cmd, args)
+        assert body is None
+        assert query == {"region": "eu"}
+        assert path == "/tenants/acme/items"

--- a/tests/test_session_spawn.py
+++ b/tests/test_session_spawn.py
@@ -1,0 +1,75 @@
+"""The session daemon must spawn where /dev/null cannot be opened."""
+
+import builtins
+import subprocess
+
+import pytest
+
+import mcp2cli
+
+
+@pytest.fixture
+def session_dirs(tmp_path, monkeypatch):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir(parents=True)
+    monkeypatch.setattr(mcp2cli, "SESSIONS_DIR", sessions)
+    return sessions
+
+
+def _spawn_kwargs(monkeypatch):
+    """Capture the kwargs session_start hands to Popen, without spawning."""
+    captured = {}
+
+    class _FakeProc:
+        """Exits immediately, so session_start reports failure and returns."""
+
+        pid = 4321
+        stdin = None
+        returncode = 1
+
+        def poll(self):
+            return 1
+
+    def fake_popen(_argv, **kwargs):
+        captured.update(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    return captured
+
+
+def test_daemon_streams_avoid_dev_null(session_dirs, monkeypatch, capsys):
+    """A sandbox that denies /dev/null must not break `--session-start`."""
+    captured = _spawn_kwargs(monkeypatch)
+    real_open = builtins.open
+
+    def guarded_open(path, *args, **kwargs):
+        if str(path) == "/dev/null":
+            raise PermissionError(13, "Permission denied", "/dev/null")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+    monkeypatch.setattr(mcp2cli.time, "sleep", lambda _seconds: None)
+
+    # The stub daemon exits at once, so session_start reports and exits; the
+    # spawn arguments are already captured by then.
+    with pytest.raises(SystemExit):
+        mcp2cli.session_start("sandboxed", "cmd", True, [], {})
+    capsys.readouterr()
+
+    assert captured["stdout"] is not subprocess.DEVNULL
+    assert captured["stderr"] is not subprocess.DEVNULL
+    assert captured["stdin"] is subprocess.PIPE
+    assert captured["start_new_session"] is True
+
+
+def test_daemon_output_lands_in_the_session_log(session_dirs, monkeypatch, capsys):
+    captured = _spawn_kwargs(monkeypatch)
+    monkeypatch.setattr(mcp2cli.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(SystemExit):
+        mcp2cli.session_start("logged", "cmd", True, [], {})
+    capsys.readouterr()
+
+    assert captured["stdout"] is captured["stderr"]
+    assert captured["stdout"].name == str(mcp2cli._session_log_path("logged"))


### PR DESCRIPTION
## Scope
Addresses all 8 open issues and all 12 existing PR tracks from the triage pass. Each track was implemented in its own worktree; original contributor commits and authorship are preserved through merges.

Fixes #95
Fixes #97
Fixes #99
Fixes #101
Fixes #103
Fixes #105
Fixes #108
Fixes #110

## Integrated contributions and follow-up fixes
- #94: typed AnyIO/builtin/MCP CONNECTION_CLOSED diagnostics; removed unrelated package-version fallback; real early-exit stdio regression.
- #96: inherited OpenAPI path/query/header parameters with operation overrides.
- #98: collision-safe OpenAPI commands, including distinct valid operationIds that normalize identically.
- #100: query/header/path/body separation, including headers with --stdin; strict HTTP request regressions.
- #102: corruption-tolerant cache reads and unique same-directory atomic writes for concurrent writers.
- #104: wrapper ownership checks, absolute installation destinations, cross-CWD removal and symlink/foreign-file protection.
- #106: GraphQL collision safety with original wire-field/operation preservation.
- #107: real filesystem-server bake examples and recursive **/*.md glob; executed against the published server.
- #109: display-only OAuth secret masking, auth-header coverage, and documented masking scope.
- #111: RFC6901 escapes, strict array indices, URI fragment decoding, and dangling-reference recovery.
- #112: issuer forwarding for manual and real localhost callbacks across supported SDK majors.
- #113: session spawn without opening /dev/null, verified with a real daemon and tool calls.
- Shared test compatibility: replace incomplete OAuth response mocks with actual SDK-flavor HTTP responses and avoid unused fixed-port listeners in refresh-only tests (latest MCP 1.30/2.2 CI compatibility).

## Verification
- Every isolated PR worktree passed its changed-path test file(s); documentation example also smoke-tested with npm filesystem server 2026.8.31.
- Complete combined suite: **501 passed per environment**, across Python **3.10.21 / 3.13.15** × MCP **1.26.0 / 1.30.0 / 2.2.0** (3,006 passing test cases). OAuth tests serialized on this shared host because existing tests use fixed callback ports; all other tests run concurrently in isolated source trees and HOME directories.
- Real CLI smoke: OpenAPI inheritance/overrides/routing, stdin headers, both naming allocators, escaped and dangling refs, secret masking, cross-CWD wrapper removal, actual disconnect hint and debug traceback.
- Six concurrent real CLI cache refreshes plus truncated-cache recovery passed.
- New regression scenarios fail against the corresponding pre-fix source for denied-/dev/null spawning, cross-CWD wrapper removal, stdin headers, BrokenPipeError diagnostics, and invalid JSON Pointer indices.

## Review/merge
The writable contributor PR branches have been updated directly. For forks that disable maintainer edits, complete standalone branches are published as `address-pr-<number>` in this repository, with fixes also included here. This PR provides a conflict-resolved, jointly verified integration point. No original PR or issue has been closed prematurely; human review is still required before merge.
